### PR TITLE
Ensure runtime storage directory is writable by quarkus

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,0 +1,19 @@
+# syntax=docker/dockerfile:1
+
+FROM maven:3.9.6-eclipse-temurin-17 AS build
+WORKDIR /project
+COPY pom.xml .
+COPY src ./src
+RUN mvn -B -DskipTests package
+
+FROM quay.io/quarkus/quarkus-micro-image:3.8
+WORKDIR /work/
+COPY --from=build /project/target/quarkus-app/lib/ /work/lib/
+COPY --from=build /project/target/quarkus-app/app/ /work/app/
+COPY --from=build /project/target/quarkus-app/quarkus/ /work/quarkus/
+COPY --from=build /project/target/quarkus-app/quarkus-run.jar /work/quarkus-run.jar
+RUN mkdir -p /opt/quarkus/storage \
+    && chown -R quarkus:quarkus /opt/quarkus/storage
+USER quarkus
+EXPOSE 8080
+ENTRYPOINT ["java","-jar","/work/quarkus-run.jar"]


### PR DESCRIPTION
## Summary
- add a multi-stage Dockerfile for the API module that builds the Quarkus application
- create `/opt/quarkus/storage` in the runtime stage and ensure it is owned by the `quarkus` user so that attached volumes inherit the correct permissions

## Testing
- `docker build -t feminine-api:latest -f api/Dockerfile api` *(fails: `docker` binary is not available in the execution environment)*
- `docker compose up api` *(fails: `docker` binary is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb06a9c5dc8321953ba24bc3426b33