### PR TITLE
Add Keycloak service and OIDC env configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Frontend configuration
+VITE_API_BASE_URL=http://localhost:8081
+VITE_OIDC_AUTHORITY=http://localhost:8080/realms/feminine
+VITE_OIDC_CLIENT_ID=feminine-web
+VITE_OIDC_REDIRECT_URI=http://localhost:5173/
+VITE_OIDC_POST_LOGOUT_REDIRECT_URI=http://localhost:5173/

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ package-lock.json
 .idea/
 vite.config.*s.*
 .env
+!/api/.env

--- a/api/.env
+++ b/api/.env
@@ -1,0 +1,6 @@
+DB_JDBC_URL=jdbc:postgresql://postgres:5432/feminine_portfolio
+DB_USER=portfolio
+DB_PASSWORD=portfolio
+OIDC_AUTH_SERVER_URL=http://keycloak:8080/realms/feminine
+OIDC_CLIENT_ID=feminine-api
+OIDC_CLIENT_SECRET=feminine-api-secret

--- a/api/.env.example
+++ b/api/.env.example
@@ -1,0 +1,9 @@
+# Database configuration
+DB_JDBC_URL=jdbc:postgresql://postgres:5432/feminine_portfolio
+DB_USER=portfolio
+DB_PASSWORD=portfolio
+
+# OIDC / Keycloak configuration
+OIDC_AUTH_SERVER_URL=http://keycloak:8080/realms/feminine
+OIDC_CLIENT_ID=feminine-api
+OIDC_CLIENT_SECRET=feminine-api-secret

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,86 @@
+version: "3.9"
+
+services:
+  postgres:
+    image: postgres:16
+    environment:
+      POSTGRES_DB: feminine_portfolio
+      POSTGRES_USER: portfolio
+      POSTGRES_PASSWORD: portfolio
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
+    networks:
+      - app
+    ports:
+      - "5432:5432"
+
+  keycloak:
+    image: quay.io/keycloak/keycloak:25.0.5
+    command:
+      - start-dev
+      - --import-realm
+    environment:
+      KEYCLOAK_ADMIN: admin
+      KEYCLOAK_ADMIN_PASSWORD: admin
+      KC_HEALTH_ENABLED: "true"
+      KC_METRICS_ENABLED: "true"
+    volumes:
+      - ./docker/keycloak:/opt/keycloak/data/import
+    depends_on:
+      postgres:
+        condition: service_healthy
+    ports:
+      - "8080:8080"
+    networks:
+      - app
+
+  api:
+    build:
+      context: ./api
+    env_file:
+      - ./api/.env
+    depends_on:
+      postgres:
+        condition: service_healthy
+      keycloak:
+        condition: service_started
+    ports:
+      - "8081:8080"
+    volumes:
+      - api-storage:/opt/quarkus/storage
+    networks:
+      - app
+
+  web:
+    image: node:20
+    working_dir: /app
+    command: ["npm", "run", "dev", "--", "--host", "0.0.0.0", "--port", "5173"]
+    environment:
+      VITE_API_BASE_URL: http://localhost:8081
+      VITE_OIDC_AUTHORITY: http://localhost:8080/realms/feminine
+      VITE_OIDC_CLIENT_ID: feminine-web
+      VITE_OIDC_REDIRECT_URI: http://localhost:5173/
+      VITE_OIDC_POST_LOGOUT_REDIRECT_URI: http://localhost:5173/
+    volumes:
+      - ./:/app
+    ports:
+      - "5173:5173"
+    depends_on:
+      api:
+        condition: service_started
+    networks:
+      - app
+
+networks:
+  app:
+    driver: bridge
+
+volumes:
+  postgres-data:
+  api-storage:

--- a/docker/keycloak/feminine-realm.json
+++ b/docker/keycloak/feminine-realm.json
@@ -1,0 +1,67 @@
+{
+  "realm": "feminine",
+  "enabled": true,
+  "sslRequired": "external",
+  "registrationAllowed": false,
+  "loginWithEmailAllowed": true,
+  "duplicateEmailsAllowed": false,
+  "resetPasswordAllowed": true,
+  "internationalizationEnabled": false,
+  "clients": [
+    {
+      "clientId": "feminine-api",
+      "name": "Feminine Portfolio API",
+      "protocol": "openid-connect",
+      "publicClient": false,
+      "secret": "feminine-api-secret",
+      "serviceAccountsEnabled": true,
+      "standardFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "authorizationServicesEnabled": false,
+      "webOrigins": [],
+      "redirectUris": [],
+      "attributes": {
+        "oidc.ciba.grant.enabled": "false",
+        "oauth2.device.authorization.grant.enabled": "true"
+      }
+    },
+    {
+      "clientId": "feminine-web",
+      "name": "Feminine Portfolio Web",
+      "protocol": "openid-connect",
+      "publicClient": true,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "redirectUris": [
+        "http://localhost:5173/*"
+      ],
+      "webOrigins": [
+        "http://localhost:5173"
+      ],
+      "attributes": {
+        "pkce.code.challenge.method": "S256",
+        "post.logout.redirect.uris": "http://localhost:5173/*"
+      }
+    }
+  ],
+  "users": [
+    {
+      "username": "elena",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Elena",
+      "lastName": "Petrova",
+      "email": "elena@example.com",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "changeit",
+          "temporary": false
+        }
+      ],
+      "realmRoles": []
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a docker compose stack for the API, frontend, Postgres, and Keycloak wired to a shared network
- provide a Keycloak realm import that seeds API and web clients along with a demo user
- document the OIDC endpoints in env templates and allow committing the API `.env`

## Testing
- `docker compose up` *(fails: Docker is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb0aa1cf048321801deced26afc514