### PR TITLE
Add shared API client configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,8 @@
 # Frontend configuration
+# Fully qualified base URL for the public API exposed to the frontend
+# (include protocol, host, port, and any context path, e.g., http://localhost:8081)
+VITE_API_URL=http://localhost:8081
+# Legacy variable supported for backwards compatibility with older builds
 VITE_API_BASE_URL=http://localhost:8081
 VITE_OIDC_AUTHORITY=http://localhost:8080/realms/feminine
 VITE_OIDC_CLIENT_ID=feminine-web

--- a/src/api/client.js
+++ b/src/api/client.js
@@ -1,0 +1,20 @@
+import axios from "axios";
+
+const rawBaseUrl =
+  import.meta.env.VITE_API_URL ?? import.meta.env.VITE_API_BASE_URL ?? "";
+const baseURL = rawBaseUrl ? rawBaseUrl.replace(/\/+$/, "") : "";
+
+const apiClient = axios.create({
+  baseURL,
+  timeout: 10000,
+  headers: {
+    Accept: "application/json",
+    "Content-Type": "application/json",
+  },
+});
+
+export const get = (url, config = {}) => apiClient.get(url, config);
+
+export const post = (url, data, config = {}) => apiClient.post(url, data, config);
+
+export default apiClient;


### PR DESCRIPTION
## Summary
- document the exposed VITE_API_URL environment variable while preserving the legacy base URL fallback
- add a shared Axios client that reads the configured base URL, applies JSON defaults, and exports reusable GET/POST helpers

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cbbb49d0608321a00effeb8a26d2ef