### PR TITLE
Run booking submission tests with Bun

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
     "dev": "vite",
     "start": "vite",
     "build": "vite build --sourcemap",
-    "serve": "vite preview"
+    "serve": "vite preview",
+    "test": "bun test"
   },
   "eslintConfig": {
     "extends": [

--- a/src/pages/booking/__tests__/bookingSubmission.test.js
+++ b/src/pages/booking/__tests__/bookingSubmission.test.js
@@ -1,0 +1,176 @@
+import { describe, expect, it, vi } from 'bun:test';
+
+import {
+  createSubmitHandler,
+  parseBookingErrors,
+  SUCCESS_TOAST_DURATION,
+} from '../bookingSubmission';
+
+const collectCallArgs = (mockFn) => mockFn.mock.calls.map((call) => call[0]);
+
+describe('booking submission orchestration', () => {
+  it('submits booking data, resets errors and schedules success timeout', async () => {
+    const submitBookingFn = vi
+      .fn()
+      .mockResolvedValue({ id: 'booking-123', status: 'confirmed' });
+    const setIsSubmitting = vi.fn();
+    const setSubmissionError = vi.fn();
+    const setServerErrors = vi.fn();
+    const setShowSuccessMessage = vi.fn();
+    const clearTimeoutFn = vi.fn();
+    const setTimeoutFn = vi.fn((callback, delay) => {
+      expect(delay).toBe(SUCCESS_TOAST_DURATION);
+      scheduledCallback = callback;
+      return 'timeout-id';
+    });
+    const successTimeoutRef = { current: 'previous-timeout' };
+    let scheduledCallback = () => {};
+
+    const handleSubmit = createSubmitHandler({
+      submitBookingFn,
+      getSelectedDate: () => '2025-01-15',
+      setIsSubmitting,
+      setSubmissionError,
+      setServerErrors,
+      setShowSuccessMessage,
+      successTimeoutRef,
+      setTimeoutFn,
+      clearTimeoutFn,
+    });
+
+    const result = await handleSubmit({
+      fullName: 'Test User',
+      email: 'test@example.com',
+      phone: '+359123456789',
+    });
+
+    expect(submitBookingFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fullName: 'Test User',
+        email: 'test@example.com',
+        phone: '+359123456789',
+        selectedDate: '2025-01-15',
+      })
+    );
+
+    expect(collectCallArgs(setIsSubmitting)).toEqual([true, false]);
+    expect(collectCallArgs(setSubmissionError)).toEqual(['']);
+    expect(collectCallArgs(setServerErrors)).toEqual([{}]);
+    expect(setShowSuccessMessage).toHaveBeenCalledWith(true);
+    expect(clearTimeoutFn).toHaveBeenCalledWith('previous-timeout');
+    expect(successTimeoutRef.current).toBe('timeout-id');
+    expect(typeof scheduledCallback).toBe('function');
+
+    // simulate auto-dismiss of the success toast
+    scheduledCallback();
+    expect(setShowSuccessMessage).toHaveBeenLastCalledWith(false);
+    expect(successTimeoutRef.current).toBeNull();
+    expect(result).toEqual({ id: 'booking-123', status: 'confirmed' });
+  });
+
+  it('captures backend validation errors and exposes form level feedback', async () => {
+    const validationError = {
+      response: {
+        data: {
+          message: 'Validation failed',
+          errors: [
+            { field: 'clientEmail', message: 'Email format is invalid on the server' },
+            { field: 'eventDate', message: 'Selected date is unavailable' },
+          ],
+        },
+      },
+    };
+
+    const submitBookingFn = vi.fn(async () => {
+      throw validationError;
+    });
+    const setIsSubmitting = vi.fn();
+    const setSubmissionError = vi.fn();
+    const setServerErrors = vi.fn();
+    const setShowSuccessMessage = vi.fn();
+    const clearTimeoutFn = vi.fn();
+    const setTimeoutFn = vi.fn();
+    const successTimeoutRef = { current: 'timeout-handle' };
+
+    const handleSubmit = createSubmitHandler({
+      submitBookingFn,
+      getSelectedDate: () => '2025-02-14',
+      setIsSubmitting,
+      setSubmissionError,
+      setServerErrors,
+      setShowSuccessMessage,
+      successTimeoutRef,
+      setTimeoutFn,
+      clearTimeoutFn,
+    });
+
+    const result = await handleSubmit({
+      fullName: 'Error Case',
+      email: 'bad-email',
+      phone: '+359987654321',
+    });
+
+    expect(result).toBeUndefined();
+    expect(setTimeoutFn).not.toHaveBeenCalled();
+    expect(clearTimeoutFn).toHaveBeenCalledWith('timeout-handle');
+    expect(successTimeoutRef.current).toBeNull();
+
+    expect(collectCallArgs(setIsSubmitting)).toEqual([true, false]);
+    expect(collectCallArgs(setSubmissionError)).toEqual(['', 'Validation failed']);
+    expect(setShowSuccessMessage).toHaveBeenCalledWith(false);
+
+    expect(setServerErrors.mock.calls[0][0]).toEqual({});
+    expect(setServerErrors.mock.calls[1][0]).toEqual({
+      email: 'Email format is invalid on the server',
+      preferredDate: 'Selected date is unavailable',
+    });
+  });
+});
+
+describe('parseBookingErrors', () => {
+  it('normalizes heterogeneous backend responses', () => {
+    const errorPayload = {
+      response: {
+        data: {
+          errors: {
+            clientPhone: ['Phone is required'],
+            extra: 'Generic issue',
+          },
+          violations: [
+            { propertyPath: 'clientName', message: 'Name is missing' },
+            { propertyPath: 'nested.selectedDate', detail: 'Selected date invalid' },
+          ],
+        },
+      },
+    };
+
+    const { fieldErrors, formError } = parseBookingErrors(errorPayload);
+
+    expect(fieldErrors).toEqual({
+      phone: 'Phone is required',
+      fullName: 'Name is missing',
+      preferredDate: 'Selected date invalid',
+      extra: 'Generic issue',
+    });
+    expect(formError).toBe('');
+  });
+
+  it('falls back to default message when nothing is provided', async () => {
+    const emptyError = { message: '' };
+    const { fieldErrors, formError } = parseBookingErrors(emptyError);
+
+    expect(fieldErrors).toEqual({});
+    expect(formError).toBe('');
+
+    const handler = createSubmitHandler({
+      submitBookingFn: vi.fn().mockRejectedValue(new Error('Network down')),
+      getSelectedDate: () => undefined,
+      setSubmissionError: vi.fn(),
+      setServerErrors: vi.fn(),
+      setShowSuccessMessage: vi.fn(),
+    });
+
+    const resultPromise = handler({});
+    await expect(resultPromise).resolves.toBeUndefined();
+  });
+});

--- a/src/pages/booking/bookingSubmission.js
+++ b/src/pages/booking/bookingSubmission.js
@@ -1,0 +1,201 @@
+export const SUCCESS_TOAST_DURATION = 5000;
+export const DEFAULT_BOOKING_ERROR_MESSAGE =
+  'Възникна грешка при изпращане на резервацията. Моля, опитайте отново. / Unable to submit the booking. Please try again.';
+
+export const normalizeFieldKey = (rawField) => {
+  if (!rawField || typeof rawField !== 'string') {
+    return null;
+  }
+
+  const segments = rawField.split('.').filter(Boolean);
+  const field = segments.length ? segments[segments.length - 1] : rawField;
+
+  const fieldMap = {
+    clientName: 'fullName',
+    clientEmail: 'email',
+    clientPhone: 'phone',
+    eventDate: 'preferredDate',
+    selectedDate: 'preferredDate',
+    photographerId: 'photographerId',
+  };
+
+  return fieldMap[field] || field;
+};
+
+const coerceMessage = (value) => {
+  if (Array.isArray(value)) {
+    return value.filter(Boolean).join(' ').trim();
+  }
+
+  if (typeof value === 'string') {
+    return value.trim();
+  }
+
+  if (value && typeof value === 'object') {
+    return (
+      value.message ||
+      value.detail ||
+      value.error ||
+      value.reason ||
+      value.description ||
+      ''
+    ).toString().trim();
+  }
+
+  return '';
+};
+
+export const parseBookingErrors = (error) => {
+  const fieldErrors = {};
+  let formError = '';
+
+  const tryAssignFieldError = (field, message) => {
+    const normalizedField = normalizeFieldKey(field);
+    if (!normalizedField) {
+      return false;
+    }
+
+    const messageText = coerceMessage(message);
+    if (!messageText) {
+      return false;
+    }
+
+    fieldErrors[normalizedField] = fieldErrors[normalizedField]
+      ? `${fieldErrors[normalizedField]} ${messageText}`
+      : messageText;
+    return true;
+  };
+
+  const responseData = error?.response?.data;
+
+  if (responseData) {
+    if (Array.isArray(responseData?.violations)) {
+      responseData.violations.forEach((violation) => {
+        const handled = tryAssignFieldError(
+          violation?.field || violation?.propertyPath,
+          violation?.message || violation?.detail
+        );
+
+        if (!handled && violation?.message) {
+          formError = formError || violation.message;
+        }
+      });
+    }
+
+    if (responseData?.errors) {
+      if (Array.isArray(responseData.errors)) {
+        responseData.errors.forEach((item) => {
+          if (typeof item === 'string') {
+            formError = formError || item;
+            return;
+          }
+
+          const handled = tryAssignFieldError(
+            item?.field || item?.propertyPath,
+            item?.message || item?.error || item?.detail
+          );
+
+          if (!handled && (item?.message || item?.error)) {
+            formError = formError || item?.message || item?.error;
+          }
+        });
+      } else if (typeof responseData.errors === 'object') {
+        Object.entries(responseData.errors).forEach(([field, value]) => {
+          const handled = tryAssignFieldError(field, value);
+          if (!handled) {
+            const fallbackMessage = coerceMessage(value);
+            if (fallbackMessage) {
+              formError = formError || fallbackMessage;
+            }
+          }
+        });
+      }
+    }
+
+    if (!formError) {
+      formError =
+        coerceMessage(responseData?.message) ||
+        coerceMessage(responseData?.error) ||
+        '';
+    }
+  } else if (error?.message) {
+    formError = error.message;
+  }
+
+  return {
+    fieldErrors,
+    formError,
+  };
+};
+
+export const createSubmitHandler = ({
+  submitBookingFn,
+  getSelectedDate,
+  setIsSubmitting,
+  setSubmissionError,
+  setServerErrors,
+  setShowSuccessMessage,
+  successTimeoutRef,
+  parseErrors = parseBookingErrors,
+  defaultErrorMessage = DEFAULT_BOOKING_ERROR_MESSAGE,
+  setTimeoutFn = setTimeout,
+  clearTimeoutFn = clearTimeout,
+} = {}) => {
+  if (typeof submitBookingFn !== 'function') {
+    throw new Error('submitBookingFn is required');
+  }
+
+  const timeoutRef = successTimeoutRef || { current: null };
+
+  return async (formData = {}) => {
+    setIsSubmitting?.(true);
+    setSubmissionError?.('');
+    setServerErrors?.({});
+
+    try {
+      const selectedDateFromState =
+        typeof getSelectedDate === 'function' ? getSelectedDate() : undefined;
+      const selectedDate = formData.selectedDate || selectedDateFromState;
+      const result = await submitBookingFn({ ...formData, selectedDate });
+
+      setShowSuccessMessage?.(true);
+
+      if (timeoutRef.current) {
+        clearTimeoutFn(timeoutRef.current);
+      }
+
+      timeoutRef.current = setTimeoutFn(() => {
+        setShowSuccessMessage?.(false);
+        timeoutRef.current = null;
+      }, SUCCESS_TOAST_DURATION);
+
+      return result;
+    } catch (caughtError) {
+      if (timeoutRef.current) {
+        clearTimeoutFn(timeoutRef.current);
+        timeoutRef.current = null;
+      }
+
+      const { fieldErrors, formError } = parseErrors(caughtError);
+
+      if (fieldErrors && Object.keys(fieldErrors).length > 0) {
+        setServerErrors?.(fieldErrors);
+      }
+
+      setSubmissionError?.(formError || defaultErrorMessage);
+      setShowSuccessMessage?.(false);
+
+      return undefined;
+    } finally {
+      setIsSubmitting?.(false);
+    }
+  };
+};
+
+export default {
+  createSubmitHandler,
+  normalizeFieldKey,
+  parseBookingErrors,
+  SUCCESS_TOAST_DURATION,
+  DEFAULT_BOOKING_ERROR_MESSAGE,
+};

--- a/src/pages/booking/components/BookingForm.jsx
+++ b/src/pages/booking/components/BookingForm.jsx
@@ -5,7 +5,13 @@ import Select from '../../../components/ui/Select';
 import { Checkbox } from '../../../components/ui/Checkbox';
 import Icon from '../../../components/AppIcon';
 
-const BookingForm = ({ onSubmit, isSubmitting }) => {
+const BookingForm = ({
+  onSubmit,
+  isSubmitting,
+  serverErrors = {},
+  submissionError = '',
+  onFieldErrorClear,
+}) => {
   const [formData, setFormData] = useState({
     fullName: '',
     email: '',
@@ -46,6 +52,9 @@ const BookingForm = ({ onSubmit, isSubmitting }) => {
     setFormData(prev => ({ ...prev, [field]: value }));
     if (errors?.[field]) {
       setErrors(prev => ({ ...prev, [field]: '' }));
+    }
+    if (serverErrors?.[field]) {
+      onFieldErrorClear?.(field);
     }
   };
 
@@ -99,6 +108,15 @@ const BookingForm = ({ onSubmit, isSubmitting }) => {
           Започнете вашето пътуване с безплатна консултация / Start your journey with a complimentary consultation
         </p>
       </div>
+      {submissionError && (
+        <div
+          role="alert"
+          className="rounded-lg border border-destructive/40 bg-destructive/10 text-sm text-destructive p-4 mb-6"
+        >
+          {submissionError}
+        </div>
+      )}
+
       <form onSubmit={handleSubmit} className="space-y-6">
         {/* Personal Information */}
         <div className="space-y-4">
@@ -113,7 +131,7 @@ const BookingForm = ({ onSubmit, isSubmitting }) => {
               placeholder="Въведете вашето име / Enter your name"
               value={formData?.fullName}
               onChange={(e) => handleInputChange('fullName', e?.target?.value)}
-              error={errors?.fullName}
+              error={errors?.fullName || serverErrors?.fullName}
               required
             />
 
@@ -123,7 +141,7 @@ const BookingForm = ({ onSubmit, isSubmitting }) => {
               placeholder="your@email.com"
               value={formData?.email}
               onChange={(e) => handleInputChange('email', e?.target?.value)}
-              error={errors?.email}
+              error={errors?.email || serverErrors?.email}
               required
             />
           </div>
@@ -134,7 +152,7 @@ const BookingForm = ({ onSubmit, isSubmitting }) => {
             placeholder="+359 XXX XXX XXX"
             value={formData?.phone}
             onChange={(e) => handleInputChange('phone', e?.target?.value)}
-            error={errors?.phone}
+            error={errors?.phone || serverErrors?.phone}
             required
           />
         </div>
@@ -151,7 +169,7 @@ const BookingForm = ({ onSubmit, isSubmitting }) => {
             options={sessionTypeOptions}
             value={formData?.sessionType}
             onChange={(value) => handleInputChange('sessionType', value)}
-            error={errors?.sessionType}
+            error={errors?.sessionType || serverErrors?.sessionType}
             required
           />
 
@@ -161,7 +179,7 @@ const BookingForm = ({ onSubmit, isSubmitting }) => {
               type="date"
               value={formData?.preferredDate}
               onChange={(e) => handleInputChange('preferredDate', e?.target?.value)}
-              error={errors?.preferredDate}
+              error={errors?.preferredDate || serverErrors?.preferredDate}
               min={new Date()?.toISOString()?.split('T')?.[0]}
               required
             />
@@ -171,6 +189,7 @@ const BookingForm = ({ onSubmit, isSubmitting }) => {
               type="date"
               value={formData?.alternateDate}
               onChange={(e) => handleInputChange('alternateDate', e?.target?.value)}
+              error={serverErrors?.alternateDate}
               min={new Date()?.toISOString()?.split('T')?.[0]}
             />
           </div>
@@ -181,6 +200,7 @@ const BookingForm = ({ onSubmit, isSubmitting }) => {
             options={locationOptions}
             value={formData?.location}
             onChange={(value) => handleInputChange('location', value)}
+            error={serverErrors?.location}
           />
         </div>
 
@@ -202,6 +222,9 @@ const BookingForm = ({ onSubmit, isSubmitting }) => {
                 value={formData?.vision}
                 onChange={(e) => handleInputChange('vision', e?.target?.value)}
               />
+              {serverErrors?.vision && (
+                <p className="text-sm text-destructive mt-2">{serverErrors?.vision}</p>
+              )}
             </div>
 
             <div>
@@ -215,6 +238,9 @@ const BookingForm = ({ onSubmit, isSubmitting }) => {
                 value={formData?.inspiration}
                 onChange={(e) => handleInputChange('inspiration', e?.target?.value)}
               />
+              {serverErrors?.inspiration && (
+                <p className="text-sm text-destructive mt-2">{serverErrors?.inspiration}</p>
+              )}
             </div>
 
             <div>
@@ -228,6 +254,9 @@ const BookingForm = ({ onSubmit, isSubmitting }) => {
                 value={formData?.specialRequests}
                 onChange={(e) => handleInputChange('specialRequests', e?.target?.value)}
               />
+              {serverErrors?.specialRequests && (
+                <p className="text-sm text-destructive mt-2">{serverErrors?.specialRequests}</p>
+              )}
             </div>
           </div>
         </div>
@@ -238,7 +267,7 @@ const BookingForm = ({ onSubmit, isSubmitting }) => {
             label="Съгласявам се с условията за ползване и политиката за поверителност / I agree to the terms of service and privacy policy"
             checked={formData?.agreedToTerms}
             onChange={(e) => handleInputChange('agreedToTerms', e?.target?.checked)}
-            error={errors?.agreedToTerms}
+            error={errors?.agreedToTerms || serverErrors?.agreedToTerms}
             required
           />
 
@@ -246,6 +275,7 @@ const BookingForm = ({ onSubmit, isSubmitting }) => {
             label="Желая да получавам новини и вдъхновение за фотография / I'd like to receive photography news and inspiration"
             checked={formData?.marketingConsent}
             onChange={(e) => handleInputChange('marketingConsent', e?.target?.checked)}
+            error={serverErrors?.marketingConsent}
           />
         </div>
 

--- a/src/pages/booking/index.jsx
+++ b/src/pages/booking/index.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Helmet } from 'react-helmet';
 import Header from '../../components/ui/Header';
 import BookingForm from './components/BookingForm';
@@ -8,29 +8,55 @@ import AvailabilityCalendar from './components/AvailabilityCalendar';
 import Button from '../../components/ui/Button';
 import Icon from '../../components/AppIcon';
 import Image from '../../components/AppImage';
+import { submitBooking } from '../../services/booking';
+import { createSubmitHandler } from './bookingSubmission';
 
 const BookingPage = () => {
   const [selectedDate, setSelectedDate] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [showSuccessMessage, setShowSuccessMessage] = useState(false);
   const [activeTab, setActiveTab] = useState('form');
+  const [serverErrors, setServerErrors] = useState({});
+  const [submissionError, setSubmissionError] = useState('');
+  const successTimeoutRef = useRef(null);
 
-  const handleFormSubmit = async (formData) => {
-    setIsSubmitting(true);
-    
-    // Simulate API call
-    await new Promise(resolve => setTimeout(resolve, 2000));
-    
-    console.log('Booking submitted:', { ...formData, selectedDate });
-    
-    setIsSubmitting(false);
-    setShowSuccessMessage(true);
-    
-    // Hide success message after 5 seconds
-    setTimeout(() => {
-      setShowSuccessMessage(false);
-    }, 5000);
+  useEffect(() => {
+    return () => {
+      if (successTimeoutRef?.current) {
+        clearTimeout(successTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  const handleFieldErrorClear = (field) => {
+    if (!field) {
+      return;
+    }
+
+    setServerErrors((prev) => {
+      if (!prev?.[field]) {
+        return prev;
+      }
+
+      const nextErrors = { ...prev };
+      delete nextErrors[field];
+      return nextErrors;
+    });
   };
+
+  const handleFormSubmit = useMemo(
+    () =>
+      createSubmitHandler({
+        submitBookingFn: submitBooking,
+        getSelectedDate: () => selectedDate,
+        setIsSubmitting,
+        setSubmissionError,
+        setServerErrors,
+        setShowSuccessMessage,
+        successTimeoutRef,
+      }),
+    [selectedDate]
+  );
 
   const handleDateSelect = (date) => {
     setSelectedDate(date);
@@ -228,9 +254,12 @@ const BookingPage = () => {
               {/* Main Content Area */}
               <div className="lg:col-span-2">
                 {activeTab === 'form' && (
-                  <BookingForm 
-                    onSubmit={handleFormSubmit} 
+                  <BookingForm
+                    onSubmit={handleFormSubmit}
                     isSubmitting={isSubmitting}
+                    serverErrors={serverErrors}
+                    submissionError={submissionError}
+                    onFieldErrorClear={handleFieldErrorClear}
                   />
                 )}
                 

--- a/src/services/__tests__/booking.test.js
+++ b/src/services/__tests__/booking.test.js
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, mock, vi } from 'bun:test';
+
+mock.module('../apiClient', () => ({
+  default: {
+    post: vi.fn(),
+  },
+}));
+
+const apiClient = (await import('../apiClient')).default;
+const { submitBooking } = await import('../booking');
+
+describe('booking service', () => {
+  beforeEach(() => {
+    apiClient.post.mockReset();
+  });
+
+  it('posts booking payload including the selected date', async () => {
+    apiClient.post.mockResolvedValue({ data: { id: 'booking-1' } });
+
+    const result = await submitBooking({
+      fullName: 'Test User',
+      email: 'test@example.com',
+      selectedDate: '2025-01-15',
+      phone: '+359123456789',
+      sessionType: 'wedding',
+    });
+
+    expect(apiClient.post).toHaveBeenCalledWith(
+      '/api/v1/bookings',
+      expect.objectContaining({
+        photographerId: expect.any(String),
+        clientName: 'Test User',
+        clientEmail: 'test@example.com',
+        selectedDate: '2025-01-15',
+        eventDate: '2025-01-15',
+        phone: '+359123456789',
+        sessionType: 'wedding',
+      })
+    );
+    expect(result).toEqual({ id: 'booking-1' });
+  });
+
+  it('falls back to preferred date when no calendar selection exists', async () => {
+    apiClient.post.mockResolvedValue({ data: { id: 'booking-2' } });
+
+    await submitBooking({
+      fullName: 'Another User',
+      email: 'another@example.com',
+      preferredDate: '2025-02-01',
+    });
+
+    expect(apiClient.post).toHaveBeenLastCalledWith(
+      '/api/v1/bookings',
+      expect.objectContaining({
+        eventDate: '2025-02-01',
+        selectedDate: '2025-02-01',
+      })
+    );
+  });
+});

--- a/src/services/apiClient.js
+++ b/src/services/apiClient.js
@@ -1,0 +1,10 @@
+import axios from 'axios';
+
+const apiClient = axios.create({
+  baseURL: import.meta.env.VITE_API_BASE_URL || '/api',
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});
+
+export default apiClient;

--- a/src/services/booking.js
+++ b/src/services/booking.js
@@ -1,0 +1,51 @@
+import apiClient from './apiClient';
+
+const DEFAULT_PHOTOGRAPHER_ID =
+  import.meta.env.VITE_DEFAULT_PHOTOGRAPHER_ID || '11111111-1111-1111-1111-111111111111';
+
+const normalizePayload = (data = {}) => {
+  const eventDate = data.selectedDate || data.preferredDate || data.eventDate;
+
+  const payload = {
+    photographerId: data.photographerId || DEFAULT_PHOTOGRAPHER_ID,
+    clientName: data.fullName || data.clientName,
+    clientEmail: data.email || data.clientEmail,
+    eventDate,
+    location: data.location || undefined,
+    totalAmount: data.totalAmount || undefined,
+    selectedDate: data.selectedDate || eventDate,
+  };
+
+  const optionalFields = {
+    phone: data.phone,
+    sessionType: data.sessionType,
+    alternateDate: data.alternateDate,
+    vision: data.vision,
+    inspiration: data.inspiration,
+    specialRequests: data.specialRequests,
+    marketingConsent: data.marketingConsent,
+    agreedToTerms: data.agreedToTerms,
+  };
+
+  Object.entries(optionalFields).forEach(([key, value]) => {
+    if (value !== undefined && value !== null && value !== '') {
+      payload[key] = value;
+    }
+  });
+
+  Object.keys(payload).forEach((key) => {
+    if (payload[key] === undefined || payload[key] === '') {
+      delete payload[key];
+    }
+  });
+
+  return payload;
+};
+
+export const submitBooking = async (formData) => {
+  const payload = normalizePayload(formData);
+  const response = await apiClient.post('/api/v1/bookings', payload);
+  return response.data;
+};
+
+export default submitBooking;

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';


### PR DESCRIPTION
## Summary
- switch the project to run tests with `bun test`, removing the vitest-specific Vite config that blocked dependency installs
- extract reusable booking submission helpers that encapsulate error parsing and success timer management
- add bun-based unit tests that validate the booking service payload mapping along with success and error flows for the submission handler

## Testing
- npm install
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cbbb31d4a08321b275d84a461a9492