### PR TITLE
Add service hooks with stable dependencies and tests

### DIFF
--- a/src/hooks/__tests__/resourceHooks.test.js
+++ b/src/hooks/__tests__/resourceHooks.test.js
@@ -1,0 +1,164 @@
+import '../../test/setupDomEnvironment';
+
+import React, { act } from 'react';
+import { beforeEach, describe, expect, it, mock, vi } from 'bun:test';
+import { createRoot } from 'react-dom/client';
+
+mock.module('../../services/stories', () => ({
+  fetchStories: vi.fn(),
+}));
+mock.module('../../services/gallery', () => ({
+  fetchGallery: vi.fn(),
+}));
+mock.module('../../services/instagram', () => ({
+  fetchInstagramFeed: vi.fn(),
+}));
+mock.module('../../services/packages', () => ({
+  fetchPackages: vi.fn(),
+}));
+
+const { fetchStories } = await import('../../services/stories');
+const { fetchGallery } = await import('../../services/gallery');
+const { fetchInstagramFeed } = await import('../../services/instagram');
+const { fetchPackages } = await import('../../services/packages');
+
+const useStories = (await import('../useStories')).default;
+const useGallery = (await import('../useGallery')).default;
+const useInstagramFeed = (await import('../useInstagramFeed')).default;
+const usePackages = (await import('../usePackages')).default;
+
+const mountHook = async (useHook, initialOptions) => {
+  const container = document.createElement('div');
+  const root = createRoot(container);
+
+  const Harness = ({ options }) => {
+    useHook(options);
+    return null;
+  };
+
+  await act(async () => {
+    root.render(<Harness options={initialOptions} />);
+  });
+
+  return {
+    rerender: async (nextOptions) => {
+      await act(async () => {
+        root.render(<Harness options={nextOptions} />);
+      });
+    },
+    unmount: () => {
+      act(() => {
+        root.unmount();
+      });
+    },
+  };
+};
+
+describe('useStories', () => {
+  beforeEach(() => {
+    fetchStories.mockReset();
+    fetchStories.mockResolvedValue([]);
+  });
+
+  it('only refetches when a tracked option changes', async () => {
+    const harness = await mountHook(useStories, {
+      photographerId: 'one',
+      limit: 3,
+    });
+
+    expect(fetchStories).toHaveBeenCalledTimes(1);
+
+    await harness.rerender({ photographerId: 'one', limit: 3 });
+    expect(fetchStories).toHaveBeenCalledTimes(1);
+
+    await harness.rerender({ photographerId: 'two', limit: 3 });
+    expect(fetchStories).toHaveBeenCalledTimes(2);
+
+    await harness.rerender({ photographerId: 'two', limit: 5 });
+    expect(fetchStories).toHaveBeenCalledTimes(3);
+
+    harness.unmount();
+  });
+});
+
+describe('useGallery', () => {
+  beforeEach(() => {
+    fetchGallery.mockReset();
+    fetchGallery.mockResolvedValue([]);
+  });
+
+  it('avoids duplicate fetches for identical filters', async () => {
+    const harness = await mountHook(useGallery, {
+      photographerId: 'one',
+      category: 'weddings',
+      limit: 4,
+    });
+
+    expect(fetchGallery).toHaveBeenCalledTimes(1);
+
+    await harness.rerender({ photographerId: 'one', category: 'weddings', limit: 4 });
+    expect(fetchGallery).toHaveBeenCalledTimes(1);
+
+    await harness.rerender({ photographerId: 'one', category: 'portraits', limit: 4 });
+    expect(fetchGallery).toHaveBeenCalledTimes(2);
+
+    await harness.rerender({ photographerId: 'one', category: 'portraits', limit: 6 });
+    expect(fetchGallery).toHaveBeenCalledTimes(3);
+
+    harness.unmount();
+  });
+});
+
+describe('useInstagramFeed', () => {
+  beforeEach(() => {
+    fetchInstagramFeed.mockReset();
+    fetchInstagramFeed.mockResolvedValue([]);
+  });
+
+  it('refetches only when instagram options change', async () => {
+    const harness = await mountHook(useInstagramFeed, {
+      photographerId: 'one',
+      limit: 6,
+    });
+
+    expect(fetchInstagramFeed).toHaveBeenCalledTimes(1);
+
+    await harness.rerender({ photographerId: 'one', limit: 6 });
+    expect(fetchInstagramFeed).toHaveBeenCalledTimes(1);
+
+    await harness.rerender({ photographerId: 'one', limit: 9 });
+    expect(fetchInstagramFeed).toHaveBeenCalledTimes(2);
+
+    await harness.rerender({ photographerId: 'two', limit: 9 });
+    expect(fetchInstagramFeed).toHaveBeenCalledTimes(3);
+
+    harness.unmount();
+  });
+});
+
+describe('usePackages', () => {
+  beforeEach(() => {
+    fetchPackages.mockReset();
+    fetchPackages.mockResolvedValue([]);
+  });
+
+  it('fetches packages once per distinct configuration', async () => {
+    const harness = await mountHook(usePackages, {
+      photographerId: 'one',
+      limit: 2,
+    });
+
+    expect(fetchPackages).toHaveBeenCalledTimes(1);
+
+    await harness.rerender({ photographerId: 'one', limit: 2 });
+    expect(fetchPackages).toHaveBeenCalledTimes(1);
+
+    await harness.rerender({ photographerId: 'one', limit: 3 });
+    expect(fetchPackages).toHaveBeenCalledTimes(2);
+
+    await harness.rerender({ photographerId: 'two', limit: 3 });
+    expect(fetchPackages).toHaveBeenCalledTimes(3);
+
+    harness.unmount();
+  });
+});

--- a/src/hooks/useGallery.js
+++ b/src/hooks/useGallery.js
@@ -1,0 +1,56 @@
+import { useMemo } from 'react';
+import { fetchGallery } from '../services/gallery';
+import useServiceFetcher from './useServiceFetcher';
+
+const DEFAULT_LIMIT = 12;
+
+const useGallery = (options = {}) => {
+  const {
+    photographerId,
+    category,
+    style,
+    season,
+    search,
+    sort,
+    cursor,
+    limit = DEFAULT_LIMIT,
+    enabled = true,
+  } = options ?? {};
+
+  const requestOptions = useMemo(() => {
+    const payload = { limit };
+
+    if (photographerId !== undefined) {
+      payload.photographerId = photographerId;
+    }
+    if (category !== undefined) {
+      payload.category = category;
+    }
+    if (style !== undefined) {
+      payload.style = style;
+    }
+    if (season !== undefined) {
+      payload.season = season;
+    }
+    if (search !== undefined) {
+      payload.search = search;
+    }
+    if (sort !== undefined) {
+      payload.sort = sort;
+    }
+    if (cursor !== undefined) {
+      payload.cursor = cursor;
+    }
+
+    return payload;
+  }, [photographerId, category, style, season, search, sort, cursor, limit]);
+
+  const query = useServiceFetcher(fetchGallery, requestOptions, enabled, []);
+
+  return {
+    ...query,
+    gallery: query.data,
+  };
+};
+
+export default useGallery;

--- a/src/hooks/useInstagramFeed.js
+++ b/src/hooks/useInstagramFeed.js
@@ -1,0 +1,44 @@
+import { useMemo } from 'react';
+import { fetchInstagramFeed } from '../services/instagram';
+import useServiceFetcher from './useServiceFetcher';
+
+const DEFAULT_LIMIT = 9;
+
+const useInstagramFeed = (options = {}) => {
+  const {
+    photographerId,
+    username,
+    hashtag,
+    cursor,
+    limit = DEFAULT_LIMIT,
+    enabled = true,
+  } = options ?? {};
+
+  const requestOptions = useMemo(() => {
+    const payload = { limit };
+
+    if (photographerId !== undefined) {
+      payload.photographerId = photographerId;
+    }
+    if (username !== undefined) {
+      payload.username = username;
+    }
+    if (hashtag !== undefined) {
+      payload.hashtag = hashtag;
+    }
+    if (cursor !== undefined) {
+      payload.cursor = cursor;
+    }
+
+    return payload;
+  }, [photographerId, username, hashtag, cursor, limit]);
+
+  const query = useServiceFetcher(fetchInstagramFeed, requestOptions, enabled, []);
+
+  return {
+    ...query,
+    posts: query.data,
+  };
+};
+
+export default useInstagramFeed;

--- a/src/hooks/usePackages.js
+++ b/src/hooks/usePackages.js
@@ -1,0 +1,48 @@
+import { useMemo } from 'react';
+import { fetchPackages } from '../services/packages';
+import useServiceFetcher from './useServiceFetcher';
+
+const DEFAULT_LIMIT = 6;
+
+const usePackages = (options = {}) => {
+  const {
+    photographerId,
+    locale,
+    currency,
+    category,
+    sort,
+    limit = DEFAULT_LIMIT,
+    enabled = true,
+  } = options ?? {};
+
+  const requestOptions = useMemo(() => {
+    const payload = { limit };
+
+    if (photographerId !== undefined) {
+      payload.photographerId = photographerId;
+    }
+    if (locale !== undefined) {
+      payload.locale = locale;
+    }
+    if (currency !== undefined) {
+      payload.currency = currency;
+    }
+    if (category !== undefined) {
+      payload.category = category;
+    }
+    if (sort !== undefined) {
+      payload.sort = sort;
+    }
+
+    return payload;
+  }, [photographerId, locale, currency, category, sort, limit]);
+
+  const query = useServiceFetcher(fetchPackages, requestOptions, enabled, []);
+
+  return {
+    ...query,
+    packages: query.data,
+  };
+};
+
+export default usePackages;

--- a/src/hooks/useServiceFetcher.js
+++ b/src/hooks/useServiceFetcher.js
@@ -1,0 +1,71 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+/**
+ * Shared data-fetching helper hook used by resource-specific hooks.
+ * It ensures that only the latest request updates the component state
+ * and exposes a stable refetch callback.
+ */
+const useServiceFetcher = (serviceFn, requestOptions, enabled = true, initialData) => {
+  const [data, setData] = useState(initialData);
+  const [error, setError] = useState(null);
+  const [isLoading, setIsLoading] = useState(Boolean(enabled));
+
+  const isMountedRef = useRef(false);
+  const requestIdRef = useRef(0);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  const fetchLatest = useCallback(async () => {
+    const requestId = ++requestIdRef.current;
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const result = await serviceFn(requestOptions);
+
+      if (!isMountedRef.current || requestId !== requestIdRef.current) {
+        return;
+      }
+
+      setData(result);
+    } catch (err) {
+      if (!isMountedRef.current || requestId !== requestIdRef.current) {
+        return;
+      }
+
+      setError(err);
+    } finally {
+      if (!isMountedRef.current || requestId !== requestIdRef.current) {
+        return;
+      }
+
+      setIsLoading(false);
+    }
+  }, [serviceFn, requestOptions]);
+
+  useEffect(() => {
+    if (!enabled) {
+      setIsLoading(false);
+      return;
+    }
+
+    fetchLatest();
+  }, [enabled, fetchLatest]);
+
+  return {
+    data,
+    error,
+    isLoading,
+    loading: isLoading,
+    isFetching: isLoading,
+    refetch: fetchLatest,
+  };
+};
+
+export default useServiceFetcher;

--- a/src/hooks/useStories.js
+++ b/src/hooks/useStories.js
@@ -1,0 +1,52 @@
+import { useMemo } from 'react';
+import { fetchStories } from '../services/stories';
+import useServiceFetcher from './useServiceFetcher';
+
+const DEFAULT_LIMIT = 6;
+
+const useStories = (options = {}) => {
+  const {
+    photographerId,
+    limit = DEFAULT_LIMIT,
+    category,
+    tag,
+    cursor,
+    locale,
+    sort,
+    enabled = true,
+  } = options ?? {};
+
+  const requestOptions = useMemo(() => {
+    const payload = { limit };
+
+    if (photographerId !== undefined) {
+      payload.photographerId = photographerId;
+    }
+    if (category !== undefined) {
+      payload.category = category;
+    }
+    if (tag !== undefined) {
+      payload.tag = tag;
+    }
+    if (cursor !== undefined) {
+      payload.cursor = cursor;
+    }
+    if (locale !== undefined) {
+      payload.locale = locale;
+    }
+    if (sort !== undefined) {
+      payload.sort = sort;
+    }
+
+    return payload;
+  }, [photographerId, limit, category, tag, cursor, locale, sort]);
+
+  const query = useServiceFetcher(fetchStories, requestOptions, enabled, []);
+
+  return {
+    ...query,
+    stories: query.data,
+  };
+};
+
+export default useStories;

--- a/src/services/gallery.js
+++ b/src/services/gallery.js
@@ -1,0 +1,16 @@
+import apiClient from './apiClient';
+
+const sanitizeParams = (params = {}) =>
+  Object.fromEntries(
+    Object.entries(params).filter(([, value]) => value !== undefined && value !== null)
+  );
+
+export const fetchGallery = async (params = {}) => {
+  const response = await apiClient.get('/api/v1/gallery', {
+    params: sanitizeParams(params),
+  });
+
+  return response.data;
+};
+
+export default fetchGallery;

--- a/src/services/instagram.js
+++ b/src/services/instagram.js
@@ -1,0 +1,16 @@
+import apiClient from './apiClient';
+
+const sanitizeParams = (params = {}) =>
+  Object.fromEntries(
+    Object.entries(params).filter(([, value]) => value !== undefined && value !== null)
+  );
+
+export const fetchInstagramFeed = async (params = {}) => {
+  const response = await apiClient.get('/api/v1/instagram/feed', {
+    params: sanitizeParams(params),
+  });
+
+  return response.data;
+};
+
+export default fetchInstagramFeed;

--- a/src/services/packages.js
+++ b/src/services/packages.js
@@ -1,0 +1,16 @@
+import apiClient from './apiClient';
+
+const sanitizeParams = (params = {}) =>
+  Object.fromEntries(
+    Object.entries(params).filter(([, value]) => value !== undefined && value !== null)
+  );
+
+export const fetchPackages = async (params = {}) => {
+  const response = await apiClient.get('/api/v1/packages', {
+    params: sanitizeParams(params),
+  });
+
+  return response.data;
+};
+
+export default fetchPackages;

--- a/src/services/stories.js
+++ b/src/services/stories.js
@@ -1,0 +1,16 @@
+import apiClient from './apiClient';
+
+const sanitizeParams = (params = {}) =>
+  Object.fromEntries(
+    Object.entries(params).filter(([, value]) => value !== undefined && value !== null)
+  );
+
+export const fetchStories = async (params = {}) => {
+  const response = await apiClient.get('/api/v1/stories', {
+    params: sanitizeParams(params),
+  });
+
+  return response.data;
+};
+
+export default fetchStories;

--- a/src/test/setupDomEnvironment.js
+++ b/src/test/setupDomEnvironment.js
@@ -1,0 +1,72 @@
+if (typeof window !== 'undefined' && typeof document !== 'undefined') {
+  // Environment already has a DOM implementation.
+} else {
+  const documentStub = {};
+
+  function createNode(tag) {
+    return {
+      tagName: tag.toUpperCase(),
+      nodeType: 1,
+      style: {},
+      _children: [],
+      ownerDocument: documentStub,
+      parentNode: null,
+      appendChild(child) {
+        child.parentNode = this;
+        this._children.push(child);
+      },
+      removeChild(child) {
+        this._children = this._children.filter((n) => n !== child);
+        child.parentNode = null;
+      },
+      insertBefore(child, ref) {
+        child.parentNode = this;
+        const idx = this._children.indexOf(ref);
+        if (idx === -1) {
+          this._children.push(child);
+        } else {
+          this._children.splice(idx, 0, child);
+        }
+      },
+      setAttribute() {},
+      removeAttribute() {},
+      addEventListener() {},
+      removeEventListener() {},
+      dispatchEvent() { return false; },
+    };
+  }
+
+  documentStub.createElement = createNode;
+  documentStub.createTextNode = (text) => ({ nodeType: 3, textContent: text, parentNode: null });
+  documentStub.createComment = () => ({ nodeType: 8 });
+  documentStub.createDocumentFragment = () => createNode('#document-fragment');
+  documentStub.body = createNode('body');
+  documentStub.documentElement = createNode('html');
+  documentStub.addEventListener = () => {};
+  documentStub.removeEventListener = () => {};
+  documentStub.activeElement = null;
+  documentStub.defaultView = {};
+
+  documentStub.documentElement.appendChild(documentStub.body);
+
+  documentStub.body.ownerDocument = documentStub;
+  documentStub.documentElement.ownerDocument = documentStub;
+
+  global.document = documentStub;
+
+  global.window = {
+    document: documentStub,
+    HTMLIFrameElement: function HTMLIFrameElement() {},
+    HTMLElement: function HTMLElement() {},
+    Node: function Node() {},
+    addEventListener() {},
+    removeEventListener() {},
+    getComputedStyle: () => ({ getPropertyValue: () => '' }),
+    navigator: { userAgent: 'test-environment' },
+  };
+
+  documentStub.defaultView = global.window;
+
+  global.navigator = window.navigator;
+  global.IS_REACT_ACT_ENVIRONMENT = true;
+}


### PR DESCRIPTION
## Summary
- add dedicated hooks for stories, gallery, instagram feed and packages that memoise request options and delegate fetching to a shared helper
- expose lightweight services for each resource so the hooks can call stable, sanitised API methods
- introduce DOM test harness and hook tests that ensure services are only re-invoked when option primitives actually change

## Testing
- bun test

------
https://chatgpt.com/codex/tasks/task_e_68cbdbc41c4c832198a347e7d6d48e9c