### PR TITLE
Add dev-only API docs navigation

### DIFF
--- a/src/Routes.jsx
+++ b/src/Routes.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { Suspense } from "react";
 import { BrowserRouter, Routes as RouterRoutes, Route } from "react-router-dom";
 import ScrollToTop from "components/ScrollToTop";
 import ErrorBoundary from "components/ErrorBoundary";
@@ -11,6 +11,9 @@ import BookingPage from './pages/booking';
 import Homepage from './pages/homepage';
 import { LanguageProvider } from './hooks/useLanguage';
 
+const isDev = import.meta.env.DEV;
+const DocsPage = isDev ? React.lazy(() => import('./pages/docs')) : null;
+
 
 const Routes = () => {
   return (
@@ -18,16 +21,19 @@ const Routes = () => {
       <LanguageProvider>
         <ErrorBoundary>
           <ScrollToTop />
-          <RouterRoutes>
-            <Route path="/" element={<Homepage />} />
-            <Route path="/homepage" element={<Homepage />} />
-            <Route path="/gallery" element={<Gallery />} />
-            <Route path="/about" element={<AboutPage />} />
-            <Route path="/investment" element={<Investment />} />
-            <Route path="/booking" element={<BookingPage />} />
-            <Route path="/admin-dashboard" element={<AdminDashboard />} />
-            <Route path="*" element={<NotFound />} />
-          </RouterRoutes>
+          <Suspense fallback={null}>
+            <RouterRoutes>
+              <Route path="/" element={<Homepage />} />
+              <Route path="/homepage" element={<Homepage />} />
+              <Route path="/gallery" element={<Gallery />} />
+              <Route path="/about" element={<AboutPage />} />
+              <Route path="/investment" element={<Investment />} />
+              <Route path="/booking" element={<BookingPage />} />
+              <Route path="/admin-dashboard" element={<AdminDashboard />} />
+              {isDev && DocsPage ? <Route path="/docs" element={<DocsPage />} /> : null}
+              <Route path="*" element={<NotFound />} />
+            </RouterRoutes>
+          </Suspense>
         </ErrorBoundary>
       </LanguageProvider>
     </BrowserRouter>

--- a/src/components/ui/Header.jsx
+++ b/src/components/ui/Header.jsx
@@ -10,6 +10,7 @@ const Header = () => {
   const location = useLocation();
   const { language, toggleLanguage, isEnglish } = useLanguage();
   const { t } = useTranslations();
+  const isDev = import.meta.env.DEV;
 
   useEffect(() => {
     const handleScroll = () => {
@@ -25,7 +26,8 @@ const Header = () => {
     { name: t('gallery'), path: '/gallery', icon: 'Camera' },
     { name: t('about'), path: '/about', icon: 'User' },
     { name: t('investment'), path: '/investment', icon: 'DollarSign' },
-    { name: t('booking'), path: '/booking', icon: 'Calendar' }
+    { name: t('booking'), path: '/booking', icon: 'Calendar' },
+    ...(isDev ? [{ name: 'Docs', path: '/docs', icon: 'FileText' }] : [])
   ];
 
   const isActivePath = (path) => location?.pathname === path;

--- a/src/pages/docs/index.jsx
+++ b/src/pages/docs/index.jsx
@@ -1,0 +1,41 @@
+import React, { useEffect } from 'react';
+import { Helmet } from 'react-helmet';
+import Header from '../../components/ui/Header';
+
+const swaggerUrl = import.meta.env.VITE_SWAGGER_UI_URL || 'http://localhost:8080/swagger-ui';
+
+const DocsPage = () => {
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, []);
+
+  return (
+    <>
+      <Helmet>
+        <title>API Documentation | Elena Rose Photography</title>
+        <meta name="description" content="Embedded Swagger UI for the Elena Rose Photography API." />
+        <link rel="canonical" href="/docs" />
+      </Helmet>
+      <div className="min-h-screen bg-background">
+        <Header />
+        <main className="pt-24 pb-12">
+          <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div className="bg-surface-elevation border border-border rounded-3xl shadow-medium overflow-hidden">
+              <iframe
+                src={swaggerUrl}
+                title="API Documentation"
+                className="w-full h-[80vh] bg-background"
+                loading="lazy"
+              />
+            </div>
+            <p className="mt-6 text-sm text-hierarchy-secondary text-center">
+              Swagger UI is loaded from the backend at {swaggerUrl}.
+            </p>
+          </div>
+        </main>
+      </div>
+    </>
+  );
+};
+
+export default DocsPage;


### PR DESCRIPTION
## Summary
- show a Docs navigation link only in development builds
- add a development-only /docs route that lazy loads a Swagger iframe page
- embed Swagger UI through a simple docs page pointing at the backend swagger endpoint

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cbe251f1d08321a9e6f8c083f4f704