### PR TITLE
Refactor investment page to use async resource hooks

### DIFF
--- a/src/hooks/__tests__/resourceHooks.test.js
+++ b/src/hooks/__tests__/resourceHooks.test.js
@@ -16,16 +16,26 @@ mock.module('../../services/instagram', () => ({
 mock.module('../../services/packages', () => ({
   fetchPackages: vi.fn(),
 }));
+mock.module('../../services/addOnServices', () => ({
+  fetchAddOnServices: vi.fn(),
+}));
+mock.module('../../services/testimonials', () => ({
+  fetchTestimonials: vi.fn(),
+}));
 
 const { fetchStories } = await import('../../services/stories');
 const { fetchGallery } = await import('../../services/gallery');
 const { fetchInstagramFeed } = await import('../../services/instagram');
 const { fetchPackages } = await import('../../services/packages');
+const { fetchAddOnServices } = await import('../../services/addOnServices');
+const { fetchTestimonials } = await import('../../services/testimonials');
 
 const useStories = (await import('../useStories')).default;
 const useGallery = (await import('../useGallery')).default;
 const useInstagramFeed = (await import('../useInstagramFeed')).default;
 const usePackages = (await import('../usePackages')).default;
+const useAddOnServices = (await import('../useAddOnServices')).default;
+const useTestimonials = (await import('../useTestimonials')).default;
 
 const mountHook = async (useHook, initialOptions) => {
   const container = document.createElement('div');
@@ -158,6 +168,60 @@ describe('usePackages', () => {
 
     await harness.rerender({ photographerId: 'two', limit: 3 });
     expect(fetchPackages).toHaveBeenCalledTimes(3);
+
+    harness.unmount();
+  });
+});
+
+describe('useAddOnServices', () => {
+  beforeEach(() => {
+    fetchAddOnServices.mockReset();
+    fetchAddOnServices.mockResolvedValue([]);
+  });
+
+  it('reuses previous results for identical options', async () => {
+    const harness = await mountHook(useAddOnServices, {
+      photographerId: 'one',
+      limit: 4,
+    });
+
+    expect(fetchAddOnServices).toHaveBeenCalledTimes(1);
+
+    await harness.rerender({ photographerId: 'one', limit: 4 });
+    expect(fetchAddOnServices).toHaveBeenCalledTimes(1);
+
+    await harness.rerender({ photographerId: 'two', limit: 4 });
+    expect(fetchAddOnServices).toHaveBeenCalledTimes(2);
+
+    await harness.rerender({ photographerId: 'two', limit: 6 });
+    expect(fetchAddOnServices).toHaveBeenCalledTimes(3);
+
+    harness.unmount();
+  });
+});
+
+describe('useTestimonials', () => {
+  beforeEach(() => {
+    fetchTestimonials.mockReset();
+    fetchTestimonials.mockResolvedValue([]);
+  });
+
+  it('only fetches testimonials when filter values change', async () => {
+    const harness = await mountHook(useTestimonials, {
+      photographerId: 'one',
+      limit: 3,
+    });
+
+    expect(fetchTestimonials).toHaveBeenCalledTimes(1);
+
+    await harness.rerender({ photographerId: 'one', limit: 3 });
+    expect(fetchTestimonials).toHaveBeenCalledTimes(1);
+
+    await harness.rerender({ photographerId: 'two', limit: 3 });
+    expect(fetchTestimonials).toHaveBeenCalledTimes(2);
+
+    await harness.rerender({ photographerId: 'two', limit: 5 });
+    expect(fetchTestimonials).toHaveBeenCalledTimes(3);
 
     harness.unmount();
   });

--- a/src/hooks/useAddOnServices.js
+++ b/src/hooks/useAddOnServices.js
@@ -1,0 +1,40 @@
+import { useMemo } from 'react';
+import { fetchAddOnServices } from '../services/addOnServices';
+import useServiceFetcher from './useServiceFetcher';
+
+const DEFAULT_LIMIT = 6;
+
+const useAddOnServices = (options = {}) => {
+  const {
+    photographerId,
+    locale,
+    currency,
+    limit = DEFAULT_LIMIT,
+    enabled = true,
+  } = options ?? {};
+
+  const requestOptions = useMemo(() => {
+    const payload = { limit };
+
+    if (photographerId !== undefined) {
+      payload.photographerId = photographerId;
+    }
+    if (locale !== undefined) {
+      payload.locale = locale;
+    }
+    if (currency !== undefined) {
+      payload.currency = currency;
+    }
+
+    return payload;
+  }, [photographerId, locale, currency, limit]);
+
+  const query = useServiceFetcher(fetchAddOnServices, requestOptions, enabled, []);
+
+  return {
+    ...query,
+    addOnServices: query.data,
+  };
+};
+
+export default useAddOnServices;

--- a/src/hooks/useTestimonials.js
+++ b/src/hooks/useTestimonials.js
@@ -1,0 +1,36 @@
+import { useMemo } from 'react';
+import { fetchTestimonials } from '../services/testimonials';
+import useServiceFetcher from './useServiceFetcher';
+
+const DEFAULT_LIMIT = 6;
+
+const useTestimonials = (options = {}) => {
+  const {
+    photographerId,
+    locale,
+    limit = DEFAULT_LIMIT,
+    enabled = true,
+  } = options ?? {};
+
+  const requestOptions = useMemo(() => {
+    const payload = { limit };
+
+    if (photographerId !== undefined) {
+      payload.photographerId = photographerId;
+    }
+    if (locale !== undefined) {
+      payload.locale = locale;
+    }
+
+    return payload;
+  }, [photographerId, locale, limit]);
+
+  const query = useServiceFetcher(fetchTestimonials, requestOptions, enabled, []);
+
+  return {
+    ...query,
+    testimonials: query.data,
+  };
+};
+
+export default useTestimonials;

--- a/src/pages/gallery/index.jsx
+++ b/src/pages/gallery/index.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Helmet } from 'react-helmet';
 import Header from '../../components/ui/Header';
 import Icon from '../../components/AppIcon';
@@ -8,6 +8,7 @@ import GalleryGrid from './components/GalleryGrid';
 import ImageLightbox from './components/ImageLightbox';
 import InspirationBoard from './components/InspirationBoard';
 import CategoryIntro from './components/CategoryIntro';
+import useGallery from '../../hooks/useGallery';
 
 const Gallery = () => {
   const [language, setLanguage] = useState('bg');
@@ -25,139 +26,96 @@ const Gallery = () => {
     setLanguage(savedLanguage);
   }, []);
 
-  // Mock gallery data
-  const galleryImages = [
-    {
-      id: 1,
-      src: "https://images.unsplash.com/photo-1519741497674-611481863552?w=800",
-      alt: "Romantic wedding ceremony",
-      category: language === 'bg' ? 'Сватби' : 'Weddings',
-      style: 'romantic',
-      season: 'summer',
-      location: language === 'bg' ? 'София, България' : 'Sofia, Bulgaria',
-      testimonial: language === 'bg' ? 'Елена улови всеки магически момент от нашия специален ден!' : 'Elena captured every magical moment of our special day!',
-      client: language === 'bg' ? 'Мария и Петър' : 'Maria & Peter',
-      categoryKey: 'weddings'
-    },
-    {
-      id: 2,
-      src: "https://images.unsplash.com/photo-1578662996442-48f60103fc96?w=600",
-      alt: "Maternity portrait in nature",
-      category: language === 'bg' ? 'Бременност' : 'Maternity',
-      style: 'romantic',
-      season: 'spring',
-      location: language === 'bg' ? 'Витоша, България' : 'Vitosha, Bulgaria',
-      testimonial: language === 'bg' ? 'Чувствах се толкова красива и уверена по време на сесията.' : 'I felt so beautiful and confident during the session.',
-      client: language === 'bg' ? 'Анна' : 'Anna',
-      categoryKey: 'maternity'
-    },
-    {
-      id: 3,
-      src: "https://images.unsplash.com/photo-1511895426328-dc8714191300?w=700",
-      alt: "Happy family portrait",
-      category: language === 'bg' ? 'Семейство' : 'Family',
-      style: 'candid',
-      season: 'autumn',
-      location: language === 'bg' ? 'Борисова градина' : 'Borisova Garden',
-      testimonial: language === 'bg' ? 'Децата се чувстваха свободно и естествено.' : 'The children felt free and natural.',
-      client: language === 'bg' ? 'Семейство Иванови' : 'Ivanov Family',
-      categoryKey: 'family'
-    },
-    {
-      id: 4,
-      src: "https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=500",
-      alt: "Professional business headshot",
-      category: language === 'bg' ? 'Портрети' : 'Headshots',
-      style: 'editorial',
-      season: 'winter',
-      location: language === 'bg' ? 'Студио София' : 'Sofia Studio',
-      testimonial: language === 'bg' ? 'Перфектни снимки за моя LinkedIn профил!' : 'Perfect photos for my LinkedIn profile!',
-      client: language === 'bg' ? 'Димитър' : 'Dimitar',
-      categoryKey: 'headshots'
-    },
-    {
-      id: 5,
-      src: "https://images.unsplash.com/photo-1516589178581-6cd7833ae3b2?w=600",
-      alt: "Romantic couples session",
-      category: language === 'bg' ? 'Двойки' : 'Couples',
-      style: 'romantic',
-      season: 'summer',
-      location: language === 'bg' ? 'Стария град, Пловдив' : 'Old Town, Plovdiv',
-      testimonial: language === 'bg' ? 'Елена улови нашата любов по най-красивия начин.' : 'Elena captured our love in the most beautiful way.',
-      client: language === 'bg' ? 'Елена и Георги' : 'Elena & Georgi',
-      categoryKey: 'couples'
-    },
-    {
-      id: 6,
-      src: "https://images.unsplash.com/photo-1606216794074-735e91aa2c92?w=800",
-      alt: "Wedding reception dance",
-      category: language === 'bg' ? 'Сватби' : 'Weddings',
-      style: 'candid',
-      season: 'autumn',
-      location: language === 'bg' ? 'Хотел Маринела' : 'Hotel Marinela',
-      categoryKey: 'weddings'
-    },
-    {
-      id: 7,
-      src: "https://images.unsplash.com/photo-1555252333-9f8e92e65df9?w=500",
-      alt: "Maternity silhouette",
-      category: language === 'bg' ? 'Бременност' : 'Maternity',
-      style: 'editorial',
-      season: 'winter',
-      location: language === 'bg' ? 'Студио' : 'Studio',
-      categoryKey: 'maternity'
-    },
-    {
-      id: 8,
-      src: "https://images.unsplash.com/photo-1609220136736-443140cffec6?w=700",
-      alt: "Family playing in park",
-      category: language === 'bg' ? 'Семейство' : 'Family',
-      style: 'candid',
-      season: 'spring',
-      location: language === 'bg' ? 'Южен парк' : 'South Park',
-      categoryKey: 'family'
-    },
-    {
-      id: 9,
-      src: "https://images.unsplash.com/photo-1573496359142-b8d87734a5a2?w=500",
-      alt: "Professional woman portrait",
-      category: language === 'bg' ? 'Портрети' : 'Headshots',
-      style: 'editorial',
-      season: 'spring',
-      location: language === 'bg' ? 'Офис център' : 'Business Center',
-      categoryKey: 'headshots'
-    },
-    {
-      id: 10,
-      src: "https://images.unsplash.com/photo-1522673607200-164d1b6ce486?w=600",
-      alt: "Engagement session in city",
-      category: language === 'bg' ? 'Двойки' : 'Couples',
-      style: 'editorial',
-      season: 'autumn',
-      location: language === 'bg' ? 'НДК, София' : 'NDK, Sofia',
-      categoryKey: 'couples'
-    },
-    {
-      id: 11,
-      src: "https://images.unsplash.com/photo-1465495976277-4387d4b0e4a6?w=800",
-      alt: "Wedding ceremony outdoor",
-      category: language === 'bg' ? 'Сватби' : 'Weddings',
-      style: 'romantic',
-      season: 'summer',
-      location: language === 'bg' ? 'Замък Равадиново' : 'Ravadinovo Castle',
-      categoryKey: 'weddings'
-    },
-    {
-      id: 12,
-      src: "https://images.unsplash.com/photo-1544005313-94ddf0286df2?w=500",
-      alt: "Maternity couple portrait",
-      category: language === 'bg' ? 'Бременност' : 'Maternity',
-      style: 'romantic',
-      season: 'summer',
-      location: language === 'bg' ? 'Морската градина' : 'Sea Garden',
-      categoryKey: 'maternity'
+  const galleryOptions = {
+    limit: 48,
+    locale: language,
+    category: activeCategory !== 'all' ? activeCategory : undefined,
+    style: activeStyle !== 'all' ? activeStyle : undefined,
+    season: activeSeason !== 'all' ? activeSeason : undefined,
+  };
+
+  const {
+    gallery: galleryData,
+    isLoading: isGalleryLoading,
+    error: galleryError,
+    refetch: refetchGallery,
+  } = useGallery(galleryOptions);
+
+  const localizeField = (value) => {
+    if (!value) {
+      return '';
     }
-  ];
+
+    if (typeof value === 'string') {
+      return value;
+    }
+
+    if (typeof value === 'object') {
+      return value?.[language] ?? value?.name ?? value?.label ?? value?.title ?? Object.values(value)?.[0] ?? '';
+    }
+
+    return '';
+  };
+
+  const galleryImages = useMemo(() => {
+    const rawGallery = Array.isArray(galleryData)
+      ? galleryData
+      : galleryData?.items ?? galleryData?.data ?? galleryData?.gallery ?? [];
+
+    return (
+      rawGallery
+        ?.map((item, index) => {
+          const baseImage = item?.image ?? item?.photo ?? item?.media ?? {};
+          const imageSource =
+            item?.src ??
+            item?.url ??
+            item?.imageUrl ??
+            item?.image ??
+            baseImage?.url ??
+            baseImage?.src ??
+            baseImage?.originalUrl ??
+            baseImage?.previewUrl;
+
+          if (!imageSource) {
+            return null;
+          }
+
+          const categoryKey =
+            item?.categoryKey ??
+            (typeof item?.category === 'object'
+              ? item?.category?.key ?? item?.category?.slug
+              : item?.categorySlug ?? item?.categoryId ?? item?.category);
+
+          const styleKey = item?.style ?? item?.styleKey ?? item?.styleSlug ?? baseImage?.style ?? 'all';
+          const seasonKey = item?.season ?? item?.seasonKey ?? item?.seasonSlug ?? baseImage?.season ?? 'all';
+
+          return {
+            id: item?.id ?? item?.imageId ?? item?.photoId ?? item?.mediaId ?? `gallery-${index}`,
+            src: imageSource,
+            alt:
+              item?.alt ??
+              baseImage?.alt ??
+              item?.title ??
+              (language === 'bg' ? 'Галерия изображение' : 'Gallery image'),
+            category:
+              localizeField(item?.categoryLabel ?? item?.categoryName ?? item?.category) ||
+              categoryKey ||
+              (language === 'bg' ? 'Галерия' : 'Gallery'),
+            style: styleKey,
+            season: seasonKey,
+            location:
+              localizeField(item?.location ?? item?.locationName ?? baseImage?.location) ||
+              (language === 'bg' ? 'София, България' : 'Sofia, Bulgaria'),
+            testimonial: localizeField(item?.testimonial ?? item?.quote),
+            client: localizeField(item?.client ?? item?.clientName ?? item?.subject),
+            categoryKey: categoryKey ?? 'all',
+          };
+        })
+        ?.filter(Boolean)
+    ) ?? [];
+  }, [galleryData, language]);
+
+  const gallerySkeletonItems = useMemo(() => Array.from({ length: 12 }), []);
 
   const translations = {
     bg: {
@@ -181,13 +139,33 @@ const Gallery = () => {
   const t = translations?.[language];
 
   // Filter images based on active filters
-  const filteredImages = galleryImages?.filter(image => {
-    const categoryMatch = activeCategory === 'all' || image?.categoryKey === activeCategory;
-    const styleMatch = activeStyle === 'all' || image?.style === activeStyle;
-    const seasonMatch = activeSeason === 'all' || image?.season === activeSeason;
-    
-    return categoryMatch && styleMatch && seasonMatch;
-  });
+  const filteredImages = useMemo(() => (
+    galleryImages?.filter((image) => {
+      const categoryMatch = activeCategory === 'all' || image?.categoryKey === activeCategory;
+      const styleMatch = activeStyle === 'all' || image?.style === activeStyle;
+      const seasonMatch = activeSeason === 'all' || image?.season === activeSeason;
+
+      return categoryMatch && styleMatch && seasonMatch;
+    }) ?? []
+  ), [galleryImages, activeCategory, activeStyle, activeSeason]);
+
+  useEffect(() => {
+    if (filteredImages?.length === 0) {
+      if (lightboxOpen) {
+        setLightboxOpen(false);
+      }
+
+      if (currentImageIndex !== 0) {
+        setCurrentImageIndex(0);
+      }
+
+      return;
+    }
+
+    if (currentImageIndex >= filteredImages.length) {
+      setCurrentImageIndex(0);
+    }
+  }, [filteredImages, currentImageIndex, lightboxOpen]);
 
   const handleLanguageToggle = () => {
     const newLanguage = language === 'bg' ? 'en' : 'bg';
@@ -225,8 +203,9 @@ const Gallery = () => {
     window.location.href = '/booking';
   };
 
-  const inspirationImages = galleryImages?.filter(img => 
-    inspirationBoard?.includes(img?.id)
+  const inspirationImages = useMemo(
+    () => galleryImages?.filter((img) => inspirationBoard?.includes(img?.id)) ?? [],
+    [galleryImages, inspirationBoard]
   );
 
   const scrollToTop = () => {
@@ -305,13 +284,71 @@ const Gallery = () => {
           />
 
           {/* Gallery Grid */}
-          <GalleryGrid
-            images={filteredImages}
-            onImageClick={handleImageClick}
-            inspirationBoard={inspirationBoard}
-            onToggleInspiration={handleToggleInspiration}
-            language={language}
-          />
+          {isGalleryLoading && (
+            <div className="columns-1 sm:columns-2 lg:columns-3 xl:columns-4 gap-4 space-y-4">
+              {gallerySkeletonItems.map((_, index) => (
+                <div
+                  key={`gallery-skeleton-${index}`}
+                  className="break-inside-avoid overflow-hidden rounded-lg shadow-soft bg-surface-elevation animate-pulse h-72"
+                >
+                  <div className="h-full w-full" />
+                </div>
+              ))}
+            </div>
+          )}
+
+          {!isGalleryLoading && galleryError && (
+            <div className="bg-white rounded-2xl shadow-soft p-10 text-center space-y-4">
+              <Icon name="AlertTriangle" size={36} className="mx-auto text-accent" />
+              <h3 className="font-heading text-2xl text-sophisticated-dark">
+                {language === 'bg' ? 'Не успяхме да заредим галерията' : 'We couldn\'t load the gallery'}
+              </h3>
+              <p className="text-hierarchy-secondary font-sophisticated">
+                {language === 'bg'
+                  ? 'Проверете връзката си и опитайте отново. Ако проблемът продължи, свържете се с нас.'
+                  : 'Please check your connection and try again. If the issue persists, get in touch with us.'}
+              </p>
+              <Button variant="outline" onClick={refetchGallery} className="elegant-hover">
+                <Icon name="RefreshCcw" size={16} className="mr-2" />
+                {language === 'bg' ? 'Опитай отново' : 'Try again'}
+              </Button>
+            </div>
+          )}
+
+          {!isGalleryLoading && !galleryError && filteredImages?.length === 0 && (
+            <div className="bg-white rounded-2xl shadow-soft p-10 text-center space-y-4">
+              <Icon name="Images" size={36} className="mx-auto text-accent" />
+              <h3 className="font-heading text-2xl text-sophisticated-dark">
+                {language === 'bg' ? 'Няма резултати за избраните филтри' : 'No results for your current filters'}
+              </h3>
+              <p className="text-hierarchy-secondary font-sophisticated">
+                {language === 'bg'
+                  ? 'Опитайте с други комбинации от категория, стил или сезон, за да откриете повече вдъхновение.'
+                  : 'Try adjusting the category, style or season to explore more inspiration.'}
+              </p>
+              <Button
+                variant="ghost"
+                onClick={() => {
+                  setActiveCategory('all');
+                  setActiveStyle('all');
+                  setActiveSeason('all');
+                }}
+                className="elegant-hover"
+              >
+                {language === 'bg' ? 'Изчисти филтрите' : 'Clear filters'}
+              </Button>
+            </div>
+          )}
+
+          {!isGalleryLoading && !galleryError && filteredImages?.length > 0 && (
+            <GalleryGrid
+              images={filteredImages}
+              onImageClick={handleImageClick}
+              inspirationBoard={inspirationBoard}
+              onToggleInspiration={handleToggleInspiration}
+              language={language}
+            />
+          )}
         </main>
 
         {/* Image Lightbox */}

--- a/src/pages/homepage/components/InstagramFeed.jsx
+++ b/src/pages/homepage/components/InstagramFeed.jsx
@@ -1,8 +1,9 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { motion } from 'framer-motion';
 import Image from '../../../components/AppImage';
 import Icon from '../../../components/AppIcon';
 import Button from '../../../components/ui/Button';
+import useInstagramFeed from '../../../hooks/useInstagramFeed';
 
 const InstagramFeed = () => {
   const [language, setLanguage] = useState('bg');
@@ -12,91 +13,69 @@ const InstagramFeed = () => {
     setLanguage(savedLanguage);
   }, []);
 
-  const instagramPosts = [
-    {
-      id: 1,
-      image: "https://images.unsplash.com/photo-1469371670807-013ccf25f16a?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=2070&q=80",
-      caption: {
-        bg: "Зад кулисите от днешната сватбена сесия ✨ Магията се случва в най-неочакваните моменти",
-        en: "Behind the scenes from today\'s wedding session ✨ Magic happens in the most unexpected moments"
-      },
-      likes: 234,
-      comments: 18,
-      timestamp: "2024-08-29T14:30:00Z"
-    },
-    {
-      id: 2,
-      image: "https://images.pexels.com/photos/1024993/pexels-photo-1024993.jpeg?auto=compress&cs=tinysrgb&w=2000&q=80",
-      caption: {
-        bg: "Златният час винаги създава най-красивата светлина за портрети 🌅",
-        en: "Golden hour always creates the most beautiful light for portraits 🌅"
-      },
-      likes: 189,
-      comments: 12,
-      timestamp: "2024-08-28T18:45:00Z"
-    },
-    {
-      id: 3,
-      image: "https://images.pixabay.com/photo/2016/03/27/07/32/woman-1282330_1280.jpg?auto=compress&cs=tinysrgb&w=2000&q=80",
-      caption: {
-        bg: "Подготовка за матернити сесия - всеки детайл има значение 💕",
-        en: "Preparing for maternity session - every detail matters 💕"
-      },
-      likes: 156,
-      comments: 8,
-      timestamp: "2024-08-27T10:15:00Z"
-    },
-    {
-      id: 4,
-      image: "https://images.unsplash.com/photo-1606216794074-735e91aa2c92?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=2087&q=80",
-      caption: {
-        bg: "Любовта е в детайлите... и в поглядите 👰‍♀️💍",
-        en: "Love is in the details... and in the glances 👰‍♀️💍"
-      },
-      likes: 312,
-      comments: 25,
-      timestamp: "2024-08-26T16:20:00Z"
-    },
-    {
-      id: 5,
-      image: "https://images.unsplash.com/photo-1511285560929-80b456fea0bc?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=2069&q=80",
-      caption: {
-        bg: "Семейните моменти са най-ценните съкровища 👨‍👩‍👧‍👦",
-        en: "Family moments are the most precious treasures 👨‍👩‍👧‍👦"
-      },
-      likes: 198,
-      comments: 14,
-      timestamp: "2024-08-25T12:00:00Z"
-    },
-    {
-      id: 6,
-      image: "https://images.pexels.com/photos/1043474/pexels-photo-1043474.jpeg?auto=compress&cs=tinysrgb&w=2000&q=80",
-      caption: {
-        bg: "Моята работна станция днес - природата е най-добрата студия 🌿",
-        en: "My workspace today - nature is the best studio 🌿"
-      },
-      likes: 145,
-      comments: 9,
-      timestamp: "2024-08-24T09:30:00Z"
+  const { posts: instagramPostsData, isLoading, error, refetch } = useInstagramFeed({
+    limit: 6,
+    username: 'elenarose_photography',
+  });
+
+  const localizeContent = (value) => {
+    if (!value) {
+      return '';
     }
-  ];
+
+    if (typeof value === 'string') {
+      return value;
+    }
+
+    if (typeof value === 'object') {
+      return value?.[language] ?? value?.caption ?? value?.text ?? Object.values(value)?.[0] ?? '';
+    }
+
+    return '';
+  };
+
+  const instagramPosts = useMemo(() => {
+    const rawPosts = Array.isArray(instagramPostsData)
+      ? instagramPostsData
+      : instagramPostsData?.items ?? instagramPostsData?.data ?? instagramPostsData?.posts ?? [];
+
+    return (
+      rawPosts
+        ?.map((post, index) => ({
+          id: post?.id ?? post?.postId ?? post?.mediaId ?? `post-${index}`,
+          image: post?.image ?? post?.imageUrl ?? post?.mediaUrl ?? post?.thumbnailUrl,
+          caption: localizeContent(post?.caption) || localizeContent(post?.description),
+          likes: post?.likes ?? post?.likeCount ?? post?.engagement?.likes ?? 0,
+          comments: post?.comments ?? post?.commentCount ?? post?.engagement?.comments ?? 0,
+          timestamp: post?.timestamp ?? post?.createdAt ?? post?.publishedAt,
+          permalink: post?.permalink ?? post?.url ?? post?.link ?? null,
+        }))
+        ?.filter((post) => post?.id)
+    ) ?? [];
+  }, [instagramPostsData, language]);
+
+  const skeletonPosts = useMemo(() => Array.from({ length: 6 }), []);
 
   const formatTimeAgo = (timestamp) => {
     const now = new Date();
-    const postTime = new Date(timestamp);
-    const diffInHours = Math.floor((now - postTime) / (1000 * 60 * 60));
-    
+    const postTime = timestamp ? new Date(timestamp) : null;
+    const diffInHours = postTime ? Math.floor((now - postTime) / (1000 * 60 * 60)) : 0;
+
+    if (!postTime || Number.isNaN(diffInHours)) {
+      return language === 'bg' ? 'скоро' : 'recently';
+    }
+
     if (language === 'bg') {
       if (diffInHours < 1) return 'преди малко';
       if (diffInHours < 24) return `преди ${diffInHours}ч`;
       const days = Math.floor(diffInHours / 24);
       return `преди ${days}д`;
-    } else {
-      if (diffInHours < 1) return 'just now';
-      if (diffInHours < 24) return `${diffInHours}h ago`;
-      const days = Math.floor(diffInHours / 24);
-      return `${days}d ago`;
     }
+
+    if (diffInHours < 1) return 'just now';
+    if (diffInHours < 24) return `${diffInHours}h ago`;
+    const days = Math.floor(diffInHours / 24);
+    return `${days}d ago`;
   };
 
   const containerVariants = {
@@ -104,9 +83,9 @@ const InstagramFeed = () => {
     visible: {
       opacity: 1,
       transition: {
-        staggerChildren: 0.1
-      }
-    }
+        staggerChildren: 0.1,
+      },
+    },
   };
 
   const itemVariants = {
@@ -116,9 +95,9 @@ const InstagramFeed = () => {
       y: 0,
       transition: {
         duration: 0.6,
-        ease: "easeOut"
-      }
-    }
+        ease: 'easeOut',
+      },
+    },
   };
 
   return (
@@ -139,8 +118,9 @@ const InstagramFeed = () => {
             </h2>
           </div>
           <p className="font-sophisticated text-lg text-hierarchy-secondary max-w-3xl mx-auto">
-            {language === 'bg' ?'Следете ме в Instagram за ежедневни вдъхновения, зад кулисите моменти и най-новите ми творения.' :'Follow me on Instagram for daily inspiration, behind-the-scenes moments and my latest creations.'
-            }
+            {language === 'bg'
+              ? 'Следете ме в Instagram за ежедневни вдъхновения, зад кулисите моменти и най-новите ми творения.'
+              : 'Follow me on Instagram for daily inspiration, behind-the-scenes moments and my latest creations.'}
           </p>
         </motion.div>
 
@@ -152,7 +132,78 @@ const InstagramFeed = () => {
           viewport={{ once: true }}
           className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6"
         >
-          {instagramPosts?.map((post) => (
+          {isLoading && (
+            <>
+              {skeletonPosts.map((_, index) => (
+                <motion.article
+                  key={`instagram-skeleton-${index}`}
+                  variants={itemVariants}
+                  className="group bg-white rounded-2xl shadow-soft overflow-hidden"
+                >
+                  <div className="relative aspect-square bg-surface-elevation animate-pulse" />
+                  <div className="p-6 space-y-4">
+                    <div className="flex items-center justify-between">
+                      <div className="flex items-center space-x-3">
+                        <div className="w-8 h-8 bg-surface-elevation animate-pulse rounded-full" />
+                        <div className="space-y-2">
+                          <div className="h-3 w-24 bg-surface-elevation animate-pulse rounded" />
+                          <div className="h-2 w-16 bg-surface-elevation animate-pulse rounded" />
+                        </div>
+                      </div>
+                      <div className="h-3 w-12 bg-surface-elevation animate-pulse rounded" />
+                    </div>
+                    <div className="space-y-2">
+                      <div className="h-3 w-full bg-surface-elevation animate-pulse rounded" />
+                      <div className="h-3 w-5/6 bg-surface-elevation animate-pulse rounded" />
+                      <div className="h-3 w-2/3 bg-surface-elevation animate-pulse rounded" />
+                    </div>
+                    <div className="flex items-center justify-between">
+                      <div className="h-3 w-20 bg-surface-elevation animate-pulse rounded" />
+                      <div className="h-3 w-10 bg-surface-elevation animate-pulse rounded" />
+                    </div>
+                  </div>
+                </motion.article>
+              ))}
+            </>
+          )}
+
+          {!isLoading && error && (
+            <motion.article variants={itemVariants} className="md:col-span-2 lg:col-span-3">
+              <div className="bg-white rounded-2xl shadow-soft p-10 text-center space-y-4">
+                <Icon name="AlertTriangle" size={36} className="mx-auto text-accent" />
+                <h3 className="font-heading text-2xl text-sophisticated-dark">
+                  {language === 'bg' ? 'Instagram не отговори навреме' : 'Instagram feed is unavailable'}
+                </h3>
+                <p className="text-hierarchy-secondary font-sophisticated">
+                  {language === 'bg'
+                    ? 'Опитайте да обновите страницата или презаредете емисията след малко.'
+                    : 'Please refresh the page or try reloading the feed in a moment.'}
+                </p>
+                <Button variant="outline" onClick={refetch} className="elegant-hover">
+                  <Icon name="RefreshCcw" size={16} className="mr-2" />
+                  {language === 'bg' ? 'Презареди емисията' : 'Reload feed'}
+                </Button>
+              </div>
+            </motion.article>
+          )}
+
+          {!isLoading && !error && instagramPosts.length === 0 && (
+            <motion.article variants={itemVariants} className="md:col-span-2 lg:col-span-3">
+              <div className="bg-white rounded-2xl shadow-soft p-10 text-center space-y-4">
+                <Icon name="CameraOff" size={36} className="mx-auto text-accent" />
+                <h3 className="font-heading text-2xl text-sophisticated-dark">
+                  {language === 'bg' ? 'Все още няма публикации' : 'No posts available yet'}
+                </h3>
+                <p className="text-hierarchy-secondary font-sophisticated">
+                  {language === 'bg'
+                    ? 'Следете профила ни в Instagram за най-новото съдържание.'
+                    : 'Follow us on Instagram to see the latest posts as they arrive.'}
+                </p>
+              </div>
+            </motion.article>
+          )}
+
+          {!isLoading && !error && instagramPosts.map((post) => (
             <motion.article
               key={post?.id}
               variants={itemVariants}
@@ -161,21 +212,21 @@ const InstagramFeed = () => {
               {/* Post Image */}
               <div className="relative aspect-square overflow-hidden">
                 <Image
-                  src={post?.image}
+                  src={post?.image ?? '/assets/images/no_image.png'}
                   alt="Instagram post"
                   className="w-full h-full object-cover gallery-image"
                 />
-                
+
                 {/* Hover Overlay */}
                 <div className="absolute inset-0 bg-black/50 opacity-0 group-hover:opacity-100 transition-opacity duration-300 flex items-center justify-center">
                   <div className="flex items-center space-x-6 text-white">
                     <div className="flex items-center space-x-2">
                       <Icon name="Heart" size={20} />
-                      <span className="font-sophisticated">{post?.likes}</span>
+                      <span className="font-sophisticated">{post?.likes ?? 0}</span>
                     </div>
                     <div className="flex items-center space-x-2">
                       <Icon name="MessageCircle" size={20} />
-                      <span className="font-sophisticated">{post?.comments}</span>
+                      <span className="font-sophisticated">{post?.comments ?? 0}</span>
                     </div>
                   </div>
                 </div>
@@ -205,7 +256,7 @@ const InstagramFeed = () => {
                 </div>
 
                 <p className="text-sophisticated-dark font-sophisticated text-sm leading-relaxed line-clamp-3">
-                  {post?.caption?.[language]}
+                  {post?.caption || (language === 'bg' ? 'Вдъхновението е на път!' : 'Fresh inspiration is on its way!')}
                 </p>
 
                 {/* Engagement Stats */}
@@ -213,16 +264,26 @@ const InstagramFeed = () => {
                   <div className="flex items-center space-x-4">
                     <button className="flex items-center space-x-1 text-hierarchy-secondary hover:text-accent transition-colors duration-300">
                       <Icon name="Heart" size={16} />
-                      <span className="text-sm font-sophisticated">{post?.likes}</span>
+                      <span className="text-sm font-sophisticated">{post?.likes ?? 0}</span>
                     </button>
                     <button className="flex items-center space-x-1 text-hierarchy-secondary hover:text-accent transition-colors duration-300">
                       <Icon name="MessageCircle" size={16} />
-                      <span className="text-sm font-sophisticated">{post?.comments}</span>
+                      <span className="text-sm font-sophisticated">{post?.comments ?? 0}</span>
                     </button>
                   </div>
-                  <button className="text-hierarchy-secondary hover:text-accent transition-colors duration-300">
-                    <Icon name="Share" size={16} />
-                  </button>
+                  {post?.permalink ? (
+                    <button
+                      className="text-hierarchy-secondary hover:text-accent transition-colors duration-300"
+                      onClick={() => window.open(post?.permalink, '_blank')}
+                      aria-label={language === 'bg' ? 'Отвори публикацията' : 'Open post'}
+                    >
+                      <Icon name="Share" size={16} />
+                    </button>
+                  ) : (
+                    <button className="text-hierarchy-secondary hover:text-accent transition-colors duration-300">
+                      <Icon name="Share" size={16} />
+                    </button>
+                  )}
                 </div>
               </div>
             </motion.article>
@@ -247,8 +308,7 @@ const InstagramFeed = () => {
           </Button>
 
           <p className="mt-4 text-hierarchy-secondary font-sophisticated">
-            {language === 'bg' ?'Присъединете се към 12.5К последователи' :'Join 12.5K followers'
-            }
+            {language === 'bg' ? 'Присъединете се към 12.5К последователи' : 'Join 12.5K followers'}
           </p>
         </motion.div>
       </div>

--- a/src/pages/homepage/components/RecentStories.jsx
+++ b/src/pages/homepage/components/RecentStories.jsx
@@ -1,8 +1,9 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { motion } from 'framer-motion';
 import Image from '../../../components/AppImage';
 import Icon from '../../../components/AppIcon';
 import Button from '../../../components/ui/Button';
+import useStories from '../../../hooks/useStories';
 
 const RecentStories = () => {
   const [language, setLanguage] = useState('bg');
@@ -12,68 +13,59 @@ const RecentStories = () => {
     setLanguage(savedLanguage);
   }, []);
 
-  const stories = [
-    {
-      id: 1,
-      title: {
-        bg: "Мария и Петър - Сватбена приказка",
-        en: "Maria & Peter - Wedding Fairytale"
-      },
-      description: {
-        bg: `Една магична есенна сватба в сърцето на Витоша планина. Мария и Петър избраха да отпразнуват любовта си сред златистите листа и топлата светлина на залязващото слънце.\n\nВсеки кадър разказва история за нежност, радост и обещания за бъдещето.`,
-        en: `A magical autumn wedding in the heart of Vitosha mountain. Maria and Peter chose to celebrate their love among golden leaves and the warm light of the setting sun.\n\nEvery frame tells a story of tenderness, joy and promises for the future.`
-      },
-      image: "https://images.unsplash.com/photo-1519741497674-611481863552?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=2070&q=80",
-      category: "wedding",
-      date: "2024-08-15",
-      location: "Витоша / Vitosha"
-    },
-    {
-      id: 2,
-      title: {
-        bg: "Елена - Очакване на чудото",
-        en: "Elena - Expecting the Miracle"
-      },
-      description: {
-        bg: `Нежна матернити сесия в златния час на деня. Елена сияеше от щастие, докато очакваше пристигането на своето първо дете.\n\nТези моменти на предвкусване и любов са безценни спомени за цялото семейство.`,
-        en: `A tender maternity session during the golden hour. Elena glowed with happiness while awaiting the arrival of her first child.\n\nThese moments of anticipation and love are priceless memories for the whole family.`
-      },
-      image: "https://images.pexels.com/photos/1556652/pexels-photo-1556652.jpeg?auto=compress&cs=tinysrgb&w=2000&q=80",
-      category: "maternity",
-      date: "2024-08-20",
-      location: "Борисова градина / Borisova Garden"
-    },
-    {
-      id: 3,
-      title: {
-        bg: "Семейство Георгиеви - Есенни спомени",
-        en: "The Georgiev Family - Autumn Memories"
-      },
-      description: {
-        bg: `Игрива семейна сесия в парка с малката Ана и нейните родители. Смехът, прегръдките и естествените моменти създадоха перфектния портрет на семейното щастие.\n\nТези кадри ще бъдат съкровище за години напред.`,
-        en: `A playful family session in the park with little Ana and her parents. Laughter, hugs and natural moments created the perfect portrait of family happiness.\n\nThese frames will be treasured for years to come.`
-      },
-      image: "https://images.pixabay.com/photo/2016/11/29/20/22/family-1871178_1280.jpg?auto=compress&cs=tinysrgb&w=2000&q=80",
-      category: "family",
-      date: "2024-08-25",
-      location: "Южен парк / South Park"
-    },
-    {
-      id: 4,
-      title: {
-        bg: "Димитър и Ива - Годежна сесия",
-        en: "Dimitar & Iva - Engagement Session"
-      },
-      description: {
-        bg: `Романтична годежна сесия в старата част на София. Димитър и Ива споделиха своята история на любов сред калдъръмените улички и историческите сгради.\n\nВсеки поглед и усмивка говореха за дълбоката им връзка.`,
-        en: `A romantic engagement session in the old part of Sofia. Dimitar and Iva shared their love story among cobblestone streets and historic buildings.\n\nEvery glance and smile spoke of their deep connection.`
-      },
-      image: "https://images.unsplash.com/photo-1516589178581-6cd7833ae3b2?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=2070&q=80",
-      category: "engagement",
-      date: "2024-08-28",
-      location: "Стария град / Old Town"
+  const { stories: storiesData, isLoading, error, refetch } = useStories({
+    limit: 4,
+    locale: language,
+  });
+
+  const localizeContent = (value) => {
+    if (!value) {
+      return '';
     }
-  ];
+
+    if (typeof value === 'string') {
+      return value;
+    }
+
+    if (typeof value === 'object') {
+      return value?.[language] ?? value?.name ?? value?.label ?? value?.title ?? Object.values(value)?.[0] ?? '';
+    }
+
+    return '';
+  };
+
+  const stories = useMemo(() => {
+    const rawStories = Array.isArray(storiesData)
+      ? storiesData
+      : storiesData?.items ?? storiesData?.data ?? storiesData?.stories ?? [];
+
+    return (
+      rawStories
+        ?.map((story, index) => {
+        const fallbackImage = story?.coverImageUrl ?? story?.imageUrl ?? story?.image ?? story?.coverImage?.url;
+        const fallbackCategory =
+          typeof story?.category === 'object'
+            ? story?.category?.key ?? story?.category?.slug ?? story?.category?.id
+            : story?.category ?? story?.categoryKey ?? story?.categorySlug;
+
+        return {
+          id: story?.id ?? story?.storyId ?? story?.slug ?? `story-${index}`,
+          title: localizeContent(story?.title) || (language === 'bg' ? 'Без заглавие' : 'Untitled'),
+          description: localizeContent(story?.description),
+          image: fallbackImage ?? story?.featuredImage ?? story?.mediaUrl ?? story?.thumbnailUrl,
+          category:
+            localizeContent(story?.categoryLabel ?? story?.categoryName ?? story?.category) ||
+            fallbackCategory ||
+            (language === 'bg' ? 'История' : 'Story'),
+          date: story?.date ?? story?.eventDate ?? story?.publishedAt ?? story?.createdAt,
+          location: localizeContent(story?.location) ?? localizeContent(story?.eventLocation),
+        };
+        })
+        ?.filter((story) => story?.id)
+    ) ?? [];
+  }, [storiesData, language]);
+
+  const skeletonCards = useMemo(() => Array.from({ length: 4 }), []);
 
   const containerVariants = {
     hidden: { opacity: 0 },
@@ -125,7 +117,75 @@ const RecentStories = () => {
           viewport={{ once: true }}
           className="grid grid-cols-1 lg:grid-cols-2 gap-8 lg:gap-12"
         >
-          {stories?.slice(0, 4)?.map((story, index) => (
+          {isLoading && (
+            <>
+              {skeletonCards.map((_, index) => (
+                <motion.article
+                  key={`story-skeleton-${index}`}
+                  variants={itemVariants}
+                  className={`group ${index % 2 === 0 ? 'lg:mt-0' : 'lg:mt-12'}`}
+                >
+                  <div className="bg-white rounded-2xl shadow-soft overflow-hidden">
+                    <div className="h-64 md:h-80 bg-surface-elevation animate-pulse" />
+                    <div className="p-6 md:p-8 space-y-4">
+                      <div className="h-6 w-3/4 bg-surface-elevation animate-pulse rounded" />
+                      <div className="h-4 w-1/3 bg-surface-elevation animate-pulse rounded" />
+                      <div className="space-y-2">
+                        <div className="h-4 w-full bg-surface-elevation animate-pulse rounded" />
+                        <div className="h-4 w-5/6 bg-surface-elevation animate-pulse rounded" />
+                        <div className="h-4 w-2/3 bg-surface-elevation animate-pulse rounded" />
+                      </div>
+                      <div className="h-10 w-32 bg-surface-elevation animate-pulse rounded-full" />
+                    </div>
+                  </div>
+                </motion.article>
+              ))}
+            </>
+          )}
+
+          {!isLoading && error && (
+            <motion.article
+              variants={itemVariants}
+              className="lg:col-span-2"
+            >
+              <div className="bg-white rounded-2xl shadow-soft p-10 text-center space-y-4">
+                <Icon name="AlertTriangle" size={36} className="mx-auto text-accent" />
+                <h3 className="font-heading text-2xl text-sophisticated-dark">
+                  {language === 'bg' ? 'Неуспешно зареждане на историите' : 'Stories failed to load'}
+                </h3>
+                <p className="text-hierarchy-secondary font-sophisticated">
+                  {language === 'bg'
+                    ? 'Моля, опитайте отново малко по-късно. Ако проблемът продължи, свържете се с нас.'
+                    : 'Please try again shortly. If the issue persists, feel free to get in touch.'}
+                </p>
+                <Button variant="outline" onClick={refetch} className="elegant-hover">
+                  <Icon name="RefreshCcw" size={16} className="mr-2" />
+                  {language === 'bg' ? 'Опитай отново' : 'Try again'}
+                </Button>
+              </div>
+            </motion.article>
+          )}
+
+          {!isLoading && !error && stories?.length === 0 && (
+            <motion.article
+              variants={itemVariants}
+              className="lg:col-span-2"
+            >
+              <div className="bg-white rounded-2xl shadow-soft p-10 text-center space-y-4">
+                <Icon name="BookOpen" size={36} className="mx-auto text-accent" />
+                <h3 className="font-heading text-2xl text-sophisticated-dark">
+                  {language === 'bg' ? 'Скоро ще споделим нови истории' : 'New stories coming soon'}
+                </h3>
+                <p className="text-hierarchy-secondary font-sophisticated">
+                  {language === 'bg'
+                    ? 'Следете галерията, за да откриете най-новите ни вдъхновяващи истории.'
+                    : 'Check back soon to explore our latest inspiring stories.'}
+                </p>
+              </div>
+            </motion.article>
+          )}
+
+          {!isLoading && !error && stories?.slice(0, 4)?.map((story, index) => (
             <motion.article
               key={story?.id}
               variants={itemVariants}
@@ -135,19 +195,19 @@ const RecentStories = () => {
                 {/* Image */}
                 <div className="relative h-64 md:h-80 overflow-hidden">
                   <Image
-                    src={story?.image}
-                    alt={story?.title?.[language]}
+                    src={story?.image ?? '/assets/images/no_image.png'}
+                    alt={story?.title}
                     className="w-full h-full object-cover gallery-image"
                   />
                   <div className="absolute top-4 left-4">
                     <span className="px-3 py-1 bg-white/90 backdrop-blur-sm rounded-full text-xs font-sophisticated text-sophisticated-dark">
-                      {story?.category?.charAt(0)?.toUpperCase() + story?.category?.slice(1)}
+                      {story?.category?.charAt?.(0)?.toUpperCase?.() + story?.category?.slice?.(1) || story?.category}
                     </span>
                   </div>
                   <div className="absolute bottom-4 right-4">
                     <div className="flex items-center space-x-2 text-white/90 text-sm">
                       <Icon name="MapPin" size={16} />
-                      <span className="font-sophisticated">{story?.location}</span>
+                      <span className="font-sophisticated">{story?.location || (language === 'bg' ? 'България' : 'Bulgaria')}</span>
                     </div>
                   </div>
                 </div>
@@ -156,15 +216,19 @@ const RecentStories = () => {
                 <div className="p-6 md:p-8">
                   <div className="flex items-center justify-between mb-4">
                     <h3 className="font-heading text-xl md:text-2xl text-sophisticated-dark">
-                      {story?.title?.[language]}
+                      {story?.title}
                     </h3>
                     <span className="text-sm text-hierarchy-secondary font-sophisticated">
-                      {new Date(story.date)?.toLocaleDateString(language === 'bg' ? 'bg-BG' : 'en-US')}
+                      {story?.date
+                        ? new Date(story.date)?.toLocaleDateString(language === 'bg' ? 'bg-BG' : 'en-US')
+                        : language === 'bg'
+                          ? 'Съвсем скоро'
+                          : 'Recently'}
                     </span>
                   </div>
-                  
+
                   <p className="text-hierarchy-secondary font-sophisticated leading-relaxed mb-6 whitespace-pre-line">
-                    {story?.description?.[language]}
+                    {story?.description || (language === 'bg' ? 'Описаниета скоро ще бъде налично.' : 'Description coming soon.')}
                   </p>
 
                   <Button

--- a/src/pages/investment/index.jsx
+++ b/src/pages/investment/index.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Helmet } from 'react-helmet';
 import Header from '../../components/ui/Header';
@@ -10,119 +10,374 @@ import ValueProposition from './components/ValueProposition';
 import TestimonialCard from './components/TestimonialCard';
 import PaymentOptions from './components/PaymentOptions';
 import SeasonalPromotion from './components/SeasonalPromotion';
+import usePackages from '../../hooks/usePackages';
+import useAddOnServices from '../../hooks/useAddOnServices';
+import useTestimonials from '../../hooks/useTestimonials';
 
 const Investment = () => {
   const navigate = useNavigate();
   const [selectedPackage, setSelectedPackage] = useState(null);
+  const [language, setLanguage] = useState('bg');
 
-  // Mock data for packages
-  const packages = [
-    {
-      id: 1,
-      name: "Essential",
-      subtitle: "Перфектно за малки събития",
-      price: "450",
-      description: "Идеален избор за интимни моменти и малки празненства. Включва основните услуги за създаване на красиви спомени.",
-      features: [
-        "1 час фотосесия",
-        "1 локация по избор",
-        "20 професионално редактирани снимки",
-        "Онлайн галерия за 30 дни",
-        "Високо разделителна способност за печат",
-        "Консултация преди сесията"
-      ]
-    },
-    {
-      id: 2,
-      name: "Signature",
-      subtitle: "Най-популярният избор",
-      price: "750",
-      description: "Нашият най-търсен пакет, който предлага перфектния баланс между стойност и качество за вашите специални моменти.",
-      features: [
-        "2 часа фотосесия",
-        "До 2 локации",
-        "50 професионално редактирани снимки",
-        "Частна онлайн галерия за 90 дни",
-        "Всички снимки в пълна резолюция",
-        "Подробна консултация и планиране",
-        "Бързо редактиране - 48 часа",
-        "Възможност за допълнителни снимки"
-      ]
-    },
-    {
-      id: 3,
-      name: "Legacy",
-      subtitle: "Пълното изживяване",
-      price: "1200",
-      description: "Премиум пакетът за тези, които искат да запазят всеки момент. Включва всичко необходимо за създаване на вечни спомени.",
-      features: [
-        "4 часа фотосесия",
-        "Неограничен брой локации",
-        "100+ професионално редактирани снимки",
-        "Частна галерия за 1 година",
-        "Всички оригинални файлове",
-        "Персонален фотоалбум (30 страници)",
-        "Приоритетно редактиране - 24 часа",
-        "Втора консултация след сесията",
-        "USB с всички снимки",
-        "Права за търговска употреба"
-      ]
+  useEffect(() => {
+    const savedLanguage = localStorage.getItem('language') || 'bg';
+    setLanguage(savedLanguage);
+  }, []);
+
+  const packageOptions = useMemo(
+    () => ({ limit: 3, locale: language, currency: 'BGN' }),
+    [language]
+  );
+
+  const addOnOptions = useMemo(
+    () => ({ limit: 6, locale: language, currency: 'BGN' }),
+    [language]
+  );
+
+  const testimonialOptions = useMemo(
+    () => ({ limit: 6, locale: language }),
+    [language]
+  );
+
+  const {
+    packages: packagesData,
+    isLoading: isPackagesLoading,
+    error: packagesError,
+    refetch: refetchPackages,
+  } = usePackages(packageOptions);
+
+  const {
+    addOnServices: addOnServicesData,
+    isLoading: isAddOnsLoading,
+    error: addOnsError,
+    refetch: refetchAddOns,
+  } = useAddOnServices(addOnOptions);
+
+  const {
+    testimonials: testimonialsData,
+    isLoading: isTestimonialsLoading,
+    error: testimonialsError,
+    refetch: refetchTestimonials,
+  } = useTestimonials(testimonialOptions);
+
+  const localizeContent = (value) => {
+    if (value === null || value === undefined) {
+      return '';
     }
-  ];
 
-  // Mock data for add-on services
-  const addOnServices = [
-    {
-      id: 1,
-      name: "Engagement Session",
-      price: "300",
-      icon: "Heart",
-      description: "Романтична предсватбена фотосесия за двойки. Перфектна за запознаване преди сватбата.",
-      features: [
-        "1 час фотосесия",
-        "15 редактирани снимки",
-        "Онлайн галерия"
-      ]
-    },
-    {
-      id: 2,
-      name: "Second Photographer",
-      price: "200",
-      icon: "Users",
-      description: "Допълнителен фотограф за по-голямо покритие и различни ъгли на събитието.",
-      features: [
-        "Пълно покритие",
-        "Различни перспективи",
-        "Повече кандидни моменти"
-      ]
-    },
-    {
-      id: 3,
-      name: "Premium Album",
-      price: "400",
-      icon: "Book",
-      description: "Луксозен фотоалбум с твърди корици и професионален печат на най-добрите снимки.",
-      features: [
-        "50 страници",
-        "Премиум материали",
-        "Персонализиран дизайн"
-      ]
-    },
-    {
-      id: 4,
-      name: "Extended Gallery",
-      price: "150",
-      icon: "Clock",
-      description: "Удължаване на достъпа до онлайн галерията за допълнителни 6 месеца.",
-      features: [
-        "6 месеца допълнително",
-        "Неограничени изтегляния",
-        "Споделяне с близки"
-      ]
+    if (typeof value === 'string' || typeof value === 'number') {
+      return value.toString();
     }
-  ];
 
-  // Mock data for value propositions
+    if (typeof value === 'object') {
+      const localized =
+        value?.[language] ??
+        value?.value ??
+        value?.text ??
+        value?.description ??
+        value?.label ??
+        value?.name ??
+        value?.title ??
+        value?.content ??
+        value?.message;
+
+      if (localized !== undefined) {
+        if (typeof localized === 'string' || typeof localized === 'number') {
+          return localized.toString();
+        }
+      }
+
+      const firstPrimitive = Object.values(value).find(
+        (entry) => typeof entry === 'string' || typeof entry === 'number'
+      );
+
+      if (firstPrimitive !== undefined) {
+        return firstPrimitive.toString();
+      }
+    }
+
+    return '';
+  };
+
+  const toArray = (value) => {
+    if (!value) {
+      return [];
+    }
+
+    if (Array.isArray(value)) {
+      return value;
+    }
+
+    if (typeof value === 'string') {
+      return value
+        .split(/\r?\n|\u2022|,/)
+        .map((item) => item.replace(/^[\s\u2022-]+/, '').trim())
+        .filter(Boolean);
+    }
+
+    if (typeof value === 'object') {
+      if (Array.isArray(value?.items)) {
+        return value.items;
+      }
+
+      if (Array.isArray(value?.data)) {
+        return value.data;
+      }
+
+      return Object.values(value);
+    }
+
+    return [];
+  };
+
+  const normalizeFeatureList = (value) =>
+    toArray(value)
+      .map((feature) => {
+        if (feature === null || feature === undefined) {
+          return '';
+        }
+
+        if (typeof feature === 'string' || typeof feature === 'number') {
+          return feature.toString();
+        }
+
+        return localizeContent(feature);
+      })
+      .filter(Boolean);
+
+  const parsePrice = (input) => {
+    if (input === null || input === undefined) {
+      return '';
+    }
+
+    if (typeof input === 'number') {
+      return input % 1 === 0 ? input.toString() : input.toFixed(2);
+    }
+
+    if (typeof input === 'string') {
+      const trimmed = input.trim();
+
+      if (!trimmed) {
+        return '';
+      }
+
+      const numericPortion = trimmed.replace(/[^0-9.,]/g, '');
+      return numericPortion || trimmed;
+    }
+
+    if (typeof input === 'object') {
+      const value =
+        input?.[language] ??
+        input?.amount ??
+        input?.value ??
+        input?.price ??
+        input?.amountValue ??
+        (typeof input?.amountCents === 'number'
+          ? input.amountCents / 100
+          : undefined) ??
+        input?.display ??
+        input?.formatted;
+
+      if (value !== undefined) {
+        return parsePrice(value);
+      }
+
+      const firstPrimitive = Object.values(input).find(
+        (entry) => typeof entry === 'string' || typeof entry === 'number'
+      );
+
+      if (firstPrimitive !== undefined) {
+        return parsePrice(firstPrimitive);
+      }
+    }
+
+    return '';
+  };
+
+  const packages = useMemo(() => {
+    const rawPackages = Array.isArray(packagesData)
+      ? packagesData
+      : packagesData?.items ??
+        packagesData?.data ??
+        packagesData?.results ??
+        packagesData?.packages ??
+        packagesData?.records ??
+        [];
+
+    return (
+      rawPackages
+        ?.map((pkg, index) => {
+          if (!pkg) {
+            return null;
+          }
+
+          const normalizedFeatures = normalizeFeatureList(
+            pkg?.features ??
+              pkg?.includedServices ??
+              pkg?.benefits ??
+              pkg?.highlights ??
+              pkg?.details ??
+              pkg?.points
+          );
+
+          const priceValue = parsePrice(
+            pkg?.price ??
+              pkg?.amount ??
+              pkg?.priceValue ??
+              pkg?.priceAmount ??
+              pkg?.price?.amount ??
+              pkg?.price?.value ??
+              pkg?.pricing ??
+              pkg?.amountValue
+          );
+
+          return {
+            id: pkg?.id ?? pkg?.packageId ?? pkg?.slug ?? pkg?.uuid ?? `package-${index}`,
+            name:
+              localizeContent(pkg?.name ?? pkg?.title) ||
+              (language === 'bg' ? 'Фотографски пакет' : 'Photography Package'),
+            subtitle: localizeContent(
+              pkg?.subtitle ??
+                pkg?.tagline ??
+                pkg?.label ??
+                pkg?.categoryLabel ??
+                pkg?.category
+            ),
+            price: priceValue,
+            description: localizeContent(
+              pkg?.description ?? pkg?.summary ?? pkg?.detailsText ?? pkg?.content
+            ),
+            features: normalizedFeatures,
+          };
+        })
+        ?.filter((pkg) => pkg?.id)
+    ) ?? [];
+  }, [packagesData, language]);
+
+  const addOnServices = useMemo(() => {
+    const rawAddOns = Array.isArray(addOnServicesData)
+      ? addOnServicesData
+      : addOnServicesData?.items ??
+        addOnServicesData?.data ??
+        addOnServicesData?.addOns ??
+        addOnServicesData?.services ??
+        addOnServicesData?.results ??
+        [];
+
+    return (
+      rawAddOns
+        ?.map((service, index) => {
+          if (!service) {
+            return null;
+          }
+
+          return {
+            id:
+              service?.id ??
+              service?.serviceId ??
+              service?.slug ??
+              service?.uuid ??
+              `add-on-${index}`,
+            name:
+              localizeContent(service?.name ?? service?.title) ||
+              (language === 'bg' ? 'Допълнителна услуга' : 'Add-on Service'),
+            price: parsePrice(
+              service?.price ??
+                service?.amount ??
+                service?.priceValue ??
+                service?.price?.amount ??
+                service?.price?.value
+            ),
+            icon:
+              service?.icon ??
+              service?.iconName ??
+              service?.iconKey ??
+              service?.icon_id ??
+              'Sparkles',
+            description: localizeContent(
+              service?.description ?? service?.summary ?? service?.details
+            ),
+            features: normalizeFeatureList(
+              service?.features ??
+                service?.highlights ??
+                service?.benefits ??
+                service?.detailsList
+            ),
+          };
+        })
+        ?.filter((service) => service?.id)
+    ) ?? [];
+  }, [addOnServicesData, language]);
+
+  const testimonials = useMemo(() => {
+    const rawTestimonials = Array.isArray(testimonialsData)
+      ? testimonialsData
+      : testimonialsData?.items ??
+        testimonialsData?.data ??
+        testimonialsData?.testimonials ??
+        testimonialsData?.results ??
+        [];
+
+    return (
+      rawTestimonials
+        ?.map((testimonial, index) => {
+          if (!testimonial) {
+            return null;
+          }
+
+          const quote = localizeContent(
+            testimonial?.quote ??
+              testimonial?.testimonial ??
+              testimonial?.feedback ??
+              testimonial?.message ??
+              testimonial?.review
+          );
+
+          if (!quote) {
+            return null;
+          }
+
+          return {
+            id:
+              testimonial?.id ??
+              testimonial?.testimonialId ??
+              testimonial?.slug ??
+              testimonial?.uuid ??
+              `testimonial-${index}`,
+            name:
+              localizeContent(
+                testimonial?.name ??
+                  testimonial?.client ??
+                  testimonial?.clientName ??
+                  testimonial?.author
+              ) || (language === 'bg' ? 'Клиент' : 'Client'),
+            session: localizeContent(
+              testimonial?.session ??
+                testimonial?.service ??
+                testimonial?.shootType ??
+                testimonial?.category ??
+                testimonial?.event
+            ),
+            avatar:
+              testimonial?.avatar ??
+              testimonial?.photo ??
+              testimonial?.image ??
+              testimonial?.imageUrl ??
+              testimonial?.avatarUrl ??
+              testimonial?.clientImage ??
+              '/assets/images/no_image.png',
+            quote,
+          };
+        })
+        ?.filter((testimonial) => testimonial?.id)
+    ) ?? [];
+  }, [testimonialsData, language]);
+
+  const packageSkeletons = useMemo(() => Array.from({ length: 3 }), []);
+  const addOnSkeletons = useMemo(() => Array.from({ length: 4 }), []);
+  const testimonialSkeletons = useMemo(() => Array.from({ length: 3 }), []);
+
+  // Value propositions remain static content on the page
   const valuePropositions = [
     {
       id: 1,
@@ -150,30 +405,6 @@ const Investment = () => {
     }
   ];
 
-  // Mock data for testimonials
-  const testimonials = [
-    {
-      id: 1,
-      name: "Мария Петрова",
-      session: "Сватбена фотосесия",
-      avatar: "https://images.unsplash.com/photo-1494790108755-2616b612b786?w=150&h=150&fit=crop&crop=face",
-      quote: "Елена улови всеки емоционален момент от нашата сватба. Снимките са като произведения на изкуството - всяка разказва история. Инвестицията си заслужаваше напълно!"
-    },
-    {
-      id: 2,
-      name: "Анна Димитрова",
-      session: "Бременност",
-      avatar: "https://images.unsplash.com/photo-1438761681033-6461ffad8d80?w=150&h=150&fit=crop&crop=face",
-      quote: "Професионализмът и вниманието към детайлите на Елена са невероятни. Тя направи фотосесията по време на бременността ми незабравима. Резултатът надмина очакванията ми."
-    },
-    {
-      id: 3,
-      name: "Георги Стоянов",
-      session: "Семейна фотосесия",
-      avatar: "https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?w=150&h=150&fit=crop&crop=face",
-      quote: "Като семейство сме много доволни от работата на Елена. Тя успя да улови естествените моменти между нас и създаде спомени, които ще пазим завинаги."
-    }
-  ];
 
   const handleSelectPackage = (pkg, type = 'package') => {
     setSelectedPackage(pkg);
@@ -263,14 +494,72 @@ const Investment = () => {
             </div>
 
             <div className="grid lg:grid-cols-3 gap-8 mb-16">
-              {packages?.map((pkg, index) => (
-                <PackageCard
-                  key={pkg?.id}
-                  package={pkg}
-                  isPopular={index === 1}
-                  onSelectPackage={handleSelectPackage}
-                />
-              ))}
+              {isPackagesLoading && (
+                <>
+                  {packageSkeletons.map((_, index) => (
+                    <div
+                      key={`package-skeleton-${index}`}
+                      className="bg-surface-elevation rounded-2xl p-8 shadow-soft animate-pulse space-y-6"
+                    >
+                      <div className="h-6 w-1/2 bg-white/10 rounded" />
+                      <div className="h-4 w-2/3 bg-white/10 rounded" />
+                      <div className="h-10 w-32 bg-white/10 rounded" />
+                      <div className="space-y-2 pt-2">
+                        {Array.from({ length: 6 }).map((__, featureIndex) => (
+                          <div key={featureIndex} className="h-4 w-full bg-white/10 rounded" />
+                        ))}
+                      </div>
+                      <div className="h-10 w-full bg-white/10 rounded-full" />
+                      <div className="h-10 w-full bg-white/10 rounded-full" />
+                    </div>
+                  ))}
+                </>
+              )}
+
+              {!isPackagesLoading && packagesError && (
+                <div className="lg:col-span-3">
+                  <div className="bg-white rounded-2xl shadow-soft p-10 text-center space-y-4">
+                    <Icon name="AlertTriangle" size={36} className="mx-auto text-accent" />
+                    <h3 className="font-heading text-2xl text-sophisticated-dark">
+                      Не успяхме да заредим пакетите
+                    </h3>
+                    <p className="text-hierarchy-secondary font-sophisticated">
+                      Проверете връзката си с интернет и опитайте отново след малко.
+                    </p>
+                    <Button variant="outline" onClick={refetchPackages} className="elegant-hover">
+                      <Icon name="RefreshCcw" size={16} className="mr-2" />
+                      Опитай отново
+                    </Button>
+                  </div>
+                </div>
+              )}
+
+              {!isPackagesLoading && !packagesError && packages?.length === 0 && (
+                <div className="lg:col-span-3">
+                  <div className="bg-white rounded-2xl shadow-soft p-10 text-center space-y-4">
+                    <Icon name="Package" size={36} className="mx-auto text-accent" />
+                    <h3 className="font-heading text-2xl text-sophisticated-dark">
+                      Скоро ще добавим нови пакети
+                    </h3>
+                    <p className="text-hierarchy-secondary font-sophisticated">
+                      Свържете се с нас за персонализирана оферта или запазете безплатна консултация.
+                    </p>
+                    <Button variant="ghost" onClick={handleBookConsultation} className="elegant-hover">
+                      Резервирайте консултация
+                    </Button>
+                  </div>
+                </div>
+              )}
+
+              {!isPackagesLoading && !packagesError &&
+                packages?.map((pkg, index) => (
+                  <PackageCard
+                    key={pkg?.id}
+                    package={pkg}
+                    isPopular={index === 1}
+                    onSelectPackage={handleSelectPackage}
+                  />
+                ))}
             </div>
 
             <div className="text-center">
@@ -302,9 +591,62 @@ const Investment = () => {
             </div>
 
             <div className="grid md:grid-cols-2 gap-6">
-              {addOnServices?.map((service) => (
-                <AddOnService key={service?.id} service={service} />
-              ))}
+              {isAddOnsLoading && (
+                <>
+                  {addOnSkeletons.map((_, index) => (
+                    <div
+                      key={`add-on-skeleton-${index}`}
+                      className="bg-surface-elevation rounded-xl p-6 animate-pulse space-y-4"
+                    >
+                      <div className="h-10 w-10 bg-white/10 rounded-full" />
+                      <div className="h-5 w-2/3 bg-white/10 rounded" />
+                      <div className="h-4 w-1/3 bg-white/10 rounded" />
+                      <div className="space-y-2 pt-2">
+                        {Array.from({ length: 3 }).map((__, featureIndex) => (
+                          <div key={featureIndex} className="h-3 w-full bg-white/10 rounded" />
+                        ))}
+                      </div>
+                    </div>
+                  ))}
+                </>
+              )}
+
+              {!isAddOnsLoading && addOnsError && (
+                <div className="md:col-span-2">
+                  <div className="bg-white rounded-2xl shadow-soft p-10 text-center space-y-4">
+                    <Icon name="AlertTriangle" size={36} className="mx-auto text-accent" />
+                    <h3 className="font-heading text-2xl text-sophisticated-dark">
+                      Не успяхме да заредим допълнителните услуги
+                    </h3>
+                    <p className="text-hierarchy-secondary font-sophisticated">
+                      Моля, опитайте отново след кратка пауза или се свържете с нас за повече информация.
+                    </p>
+                    <Button variant="outline" onClick={refetchAddOns} className="elegant-hover">
+                      <Icon name="RefreshCcw" size={16} className="mr-2" />
+                      Опитай отново
+                    </Button>
+                  </div>
+                </div>
+              )}
+
+              {!isAddOnsLoading && !addOnsError && addOnServices?.length === 0 && (
+                <div className="md:col-span-2">
+                  <div className="bg-white rounded-2xl shadow-soft p-10 text-center space-y-4">
+                    <Icon name="Puzzle" size={36} className="mx-auto text-accent" />
+                    <h3 className="font-heading text-2xl text-sophisticated-dark">
+                      В момента няма допълнителни услуги
+                    </h3>
+                    <p className="text-hierarchy-secondary font-sophisticated">
+                      Свържете се с нас, за да изградим пакет, който отговаря на вашите нужди.
+                    </p>
+                  </div>
+                </div>
+              )}
+
+              {!isAddOnsLoading && !addOnsError &&
+                addOnServices?.map((service) => (
+                  <AddOnService key={service?.id} service={service} />
+                ))}
             </div>
           </div>
         </section>
@@ -440,9 +782,67 @@ const Investment = () => {
             </div>
 
             <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
-              {testimonials?.map((testimonial) => (
-                <TestimonialCard key={testimonial?.id} testimonial={testimonial} />
-              ))}
+              {isTestimonialsLoading && (
+                <>
+                  {testimonialSkeletons.map((_, index) => (
+                    <div
+                      key={`testimonial-skeleton-${index}`}
+                      className="bg-surface-elevation rounded-xl p-8 shadow-soft animate-pulse space-y-4"
+                    >
+                      <div className="flex space-x-2">
+                        {Array.from({ length: 5 }).map((__, starIndex) => (
+                          <div key={starIndex} className="h-4 w-4 bg-white/10 rounded" />
+                        ))}
+                      </div>
+                      <div className="h-16 w-full bg-white/10 rounded" />
+                      <div className="flex items-center space-x-4 pt-4">
+                        <div className="w-12 h-12 bg-white/10 rounded-full" />
+                        <div className="flex-1 space-y-2">
+                          <div className="h-4 w-1/2 bg-white/10 rounded" />
+                          <div className="h-3 w-1/3 bg-white/10 rounded" />
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </>
+              )}
+
+              {!isTestimonialsLoading && testimonialsError && (
+                <div className="md:col-span-2 lg:col-span-3">
+                  <div className="bg-white rounded-2xl shadow-soft p-10 text-center space-y-4">
+                    <Icon name="AlertTriangle" size={36} className="mx-auto text-accent" />
+                    <h3 className="font-heading text-2xl text-sophisticated-dark">
+                      Не успяхме да заредим отзивите
+                    </h3>
+                    <p className="text-hierarchy-secondary font-sophisticated">
+                      Рефрешнете страницата или опитайте отново по-късно. Благодарим за търпението!
+                    </p>
+                    <Button variant="outline" onClick={refetchTestimonials} className="elegant-hover">
+                      <Icon name="RefreshCcw" size={16} className="mr-2" />
+                      Опитай отново
+                    </Button>
+                  </div>
+                </div>
+              )}
+
+              {!isTestimonialsLoading && !testimonialsError && testimonials?.length === 0 && (
+                <div className="md:col-span-2 lg:col-span-3">
+                  <div className="bg-white rounded-2xl shadow-soft p-10 text-center space-y-4">
+                    <Icon name="MessageCircle" size={36} className="mx-auto text-accent" />
+                    <h3 className="font-heading text-2xl text-sophisticated-dark">
+                      Първите истории тепърва предстоят
+                    </h3>
+                    <p className="text-hierarchy-secondary font-sophisticated">
+                      Бъдете сред първите, които ще споделят своя опит с Elena Rose Photography.
+                    </p>
+                  </div>
+                </div>
+              )}
+
+              {!isTestimonialsLoading && !testimonialsError &&
+                testimonials?.map((testimonial) => (
+                  <TestimonialCard key={testimonial?.id} testimonial={testimonial} />
+                ))}
             </div>
           </div>
         </section>

--- a/src/services/addOnServices.js
+++ b/src/services/addOnServices.js
@@ -1,0 +1,16 @@
+import apiClient from './apiClient';
+
+const sanitizeParams = (params = {}) =>
+  Object.fromEntries(
+    Object.entries(params).filter(([, value]) => value !== undefined && value !== null)
+  );
+
+export const fetchAddOnServices = async (params = {}) => {
+  const response = await apiClient.get('/api/v1/add-ons', {
+    params: sanitizeParams(params),
+  });
+
+  return response.data;
+};
+
+export default fetchAddOnServices;

--- a/src/services/testimonials.js
+++ b/src/services/testimonials.js
@@ -1,0 +1,16 @@
+import apiClient from './apiClient';
+
+const sanitizeParams = (params = {}) =>
+  Object.fromEntries(
+    Object.entries(params).filter(([, value]) => value !== undefined && value !== null)
+  );
+
+export const fetchTestimonials = async (params = {}) => {
+  const response = await apiClient.get('/api/v1/testimonials', {
+    params: sanitizeParams(params),
+  });
+
+  return response.data;
+};
+
+export default fetchTestimonials;


### PR DESCRIPTION
## Summary
- fetch homepage stories, instagram feed, and gallery content through their resource hooks with localized fallbacks and loading/error states
- add shared services/hooks for add-on services and testimonials, expanding resource hook test coverage
- replace investment page mock data with live hook data, normalizing responses and surfacing loading, error, and empty states across sections

## Testing
- bun test

------
https://chatgpt.com/codex/tasks/task_e_68cbe81a6afc832196fe774999c0ecee