### PR TITLE
docs: add platform audit and onboarding guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,107 +1,72 @@
-# React
+# Feminine Photography Portfolio
 
-A modern React-based project utilizing the latest frontend technologies and tools for building responsive web applications.
+A full-stack platform that combines a Vite-powered marketing site with a Quarkus API for managing photographers, bookings, inquiries, albums, and galleries.
 
-## 🚀 Features
+## Prerequisites
+- **Java 21 (Temurin or OpenJDK)** for the Quarkus API. The current Maven compiler target is 17 and will be bumped to 21 during the modernization effort, so ensure your toolchain can run both.【F:api/pom.xml†L14-L25】
+- **Maven 3.9+** to build and run the API module.【F:api/pom.xml†L11-L186】
+- **Node.js 20+ and npm** for the front-end Vite application and its development tooling.【F:package.json†L1-L52】
+- **Docker & Docker Compose v2** for running PostgreSQL, Keycloak, and full-stack smoke environments.【F:docker-compose.yml†L1-L73】
 
-- **React 18** - React version with improved rendering and concurrent features
-- **Vite** - Lightning-fast build tool and development server
-- **Redux Toolkit** - State management with simplified Redux setup
-- **TailwindCSS** - Utility-first CSS framework with extensive customization
-- **React Router v6** - Declarative routing for React applications
-- **Data Visualization** - Integrated D3.js and Recharts for powerful data visualization
-- **Form Management** - React Hook Form for efficient form handling
-- **Animation** - Framer Motion for smooth UI animations
-- **Testing** - Jest and React Testing Library setup
+## Environment configuration
+1. Copy the web template and supply local values:
+   ```bash
+   cp .env.example .env
+   ```
+   Customize the Vite variables to point at your API/Keycloak endpoints. Never commit `.env`; rely on the template instead.【F:.env.example†L1-L10】
+2. Copy the backend template and provide JDBC, OIDC, and mail settings:
+   ```bash
+   cp api/.env.example api/.env
+   ```
+   The committed file is for illustration only—store real credentials outside of Git and rotate them through GitHub Secrets for CI/CD environments.【F:api/.env.example†L1-L23】【F:api/.env†L1-L6】
+3. Production secrets (database passwords, OIDC clients, SMTP credentials, S3 keys) must live in GitHub Secrets or your runtime secret manager. Reference them from CI workflows and infrastructure automation rather than hard-coding values in Compose files or application properties.【F:docker-compose.yml†L23-L60】【F:api/src/main/resources/application.properties†L1-L63】
 
-## 📋 Prerequisites
+## Module structure
+| Module | Location | Description |
+| --- | --- | --- |
+| `web` | `/` | React 18 + Vite marketing site, localization provider, and API-aware services for bookings, galleries, and stories.【F:src/Routes.jsx†L1-L37】【F:src/services/booking.js†L1-L42】 |
+| `api` | `/api` | Quarkus 3 service with REST resources, Flyway migrations, Testcontainers-based tests, and email workflows.【F:api/pom.xml†L11-L109】【F:api/src/main/resources/db/migration/V1__create_tables.sql†L1-L200】 |
+| `infra` | *(planned)* | Infrastructure-as-code definition for cloud databases, object storage, identity, and networking. Until it lands, docker-compose provides local orchestration only.【F:docker-compose.yml†L1-L73】 |
 
-- Node.js (v14.x or higher)
-- npm or yarn
-
-## 🛠️ Installation
-
-1. Install dependencies:
+## Quick start
+### Local development (manual processes)
+1. Ensure Docker is running, then start backing services:
+   ```bash
+   docker compose up -d postgres keycloak
+   ```
+   The services expose PostgreSQL on `5432` and Keycloak on `8080` with the imported `feminine` realm.【F:docker-compose.yml†L4-L44】【F:docker/keycloak/feminine-realm.json†L1-L48】
+2. Launch the API in dev mode:
+   ```bash
+   cd api
+   mvn quarkus:dev
+   ```
+   Quarkus auto-runs Flyway migrations and serves OpenAPI/Swagger on `/q/openapi` and `/swagger-ui`.【F:api/src/main/resources/application.properties†L1-L63】
+3. In a new terminal, install web dependencies and start Vite:
    ```bash
    npm install
-   # or
-   yarn install
+   npm run dev
    ```
-   
-2. Start the development server:
+   The site runs on `http://localhost:5173` and proxies API requests using the values from `.env`.【F:package.json†L1-L52】【F:src/services/apiClient.js†L1-L9】
+
+### Local development (docker-compose)
+1. Build and run the full stack:
    ```bash
-   npm start
-   # or
-   yarn start
+   docker compose up --build
    ```
+2. Compose exposes the web app on `5173`, the API on `8081`, Keycloak on `8080`, and PostgreSQL on `5432`. Update `.env` files before running so containers pick up the correct secrets and redirect URIs.【F:docker-compose.yml†L1-L73】
+3. Stop the stack with `docker compose down` when finished. Use `docker compose down -v` to reset local PostgreSQL data volumes.
 
-## 📁 Project Structure
+## CI/CD overview
+- GitHub Actions workflows will build/test the `web` and `api` modules, publish container images, and apply infrastructure changes once the `infra` module lands. Secrets such as database passwords, OIDC credentials, and AWS keys must be injected via GitHub Secrets to keep pipelines compliant with the epic’s security requirements.【d93ced†L1-L9】【F:api/.env.example†L1-L23】
+- Until automation is added, run `mvn verify` in `api/` (requires Docker for Testcontainers) and `npm run build` in the repo root before opening pull requests.【F:api/src/test/java/com/feminine/api/config/PostgresResource.java†L1-L34】【F:package.json†L35-L52】
 
-```
-react_app/
-├── public/             # Static assets
-├── src/
-│   ├── components/     # Reusable UI components
-│   ├── pages/          # Page components
-│   ├── styles/         # Global styles and Tailwind configuration
-│   ├── App.jsx         # Main application component
-│   ├── Routes.jsx      # Application routes
-│   └── index.jsx       # Application entry point
-├── .env                # Environment variables
-├── index.html          # HTML template
-├── package.json        # Project dependencies and scripts
-├── tailwind.config.js  # Tailwind CSS configuration
-└── vite.config.js      # Vite configuration
-```
+## Troubleshooting
+- **Testcontainers errors**: Ensure Docker is running and accessible when executing `mvn verify`; the suite starts a PostgreSQL 16 container automatically.【F:api/src/test/java/com/feminine/api/config/PostgresResource.java†L1-L34】
+- **Flyway migration failures**: Confirm your database credentials in `api/.env` match the target database and that the schema is empty or versioned; migrations live under `src/main/resources/db/migration`.【F:api/src/main/resources/db/migration/V1__create_tables.sql†L1-L200】
+- **OIDC login issues**: Verify Keycloak is using the imported realm and that the Vite `.env` values for `VITE_OIDC_*` line up with the compose-hosted Keycloak endpoints.【F:docker/keycloak/feminine-realm.json†L1-L48】【F:.env.example†L1-L10】
+- **Port conflicts**: Adjust host port mappings in `docker-compose.yml` if 5173, 8080, 8081, or 5432 are occupied locally.【F:docker-compose.yml†L1-L73】
+- **Missing Bun runtime**: The web `test` script currently points to `bun test`. Replace it with Jest or Vitest locally until the script is updated in source control.【F:package.json†L43-L52】
 
-## 🧩 Adding Routes
-
-To add new routes to the application, update the `Routes.jsx` file:
-
-```jsx
-import { useRoutes } from "react-router-dom";
-import HomePage from "pages/HomePage";
-import AboutPage from "pages/AboutPage";
-
-const ProjectRoutes = () => {
-  let element = useRoutes([
-    { path: "/", element: <HomePage /> },
-    { path: "/about", element: <AboutPage /> },
-    // Add more routes as needed
-  ]);
-
-  return element;
-};
-```
-
-## 🎨 Styling
-
-This project uses Tailwind CSS for styling. The configuration includes:
-
-- Forms plugin for form styling
-- Typography plugin for text styling
-- Aspect ratio plugin for responsive elements
-- Container queries for component-specific responsive design
-- Fluid typography for responsive text
-- Animation utilities
-
-## 📱 Responsive Design
-
-The app is built with responsive design using Tailwind CSS breakpoints.
-
-
-## 📦 Deployment
-
-Build the application for production:
-
-```bash
-npm run build
-```
-
-## 🙏 Acknowledgments
-
-- Built with [Rocket.new](https://rocket.new)
-- Powered by React and Vite
-- Styled with Tailwind CSS
-
-Built with ❤️ on Rocket.new
+## Secret management
+- Treat `.env.example` and `api/.env.example` as the single source of documented configuration; copy them locally, but never commit real credentials.【F:.env.example†L1-L10】【F:api/.env.example†L1-L23】
+- Store production secrets in GitHub Secrets or your cloud secret manager and reference them from CI/CD and IaC modules. Remove any default credentials from `docker-compose.yml` or Keycloak exports before promoting to shared environments.【F:docker-compose.yml†L23-L60】【F:docker/keycloak/feminine-realm.json†L1-L48】

--- a/api/.env.example
+++ b/api/.env.example
@@ -1,9 +1,23 @@
-# Database configuration
-DB_JDBC_URL=jdbc:postgresql://postgres:5432/feminine_portfolio
+# Copy this template to api/.env for local development.
+# Never commit credentials or production values.
+DB_JDBC_URL=jdbc:postgresql://localhost:5432/feminine_portfolio
 DB_USER=portfolio
 DB_PASSWORD=portfolio
-
-# OIDC / Keycloak configuration
-OIDC_AUTH_SERVER_URL=http://keycloak:8080/realms/feminine
+OIDC_AUTH_SERVER_URL=http://localhost:8080/realms/feminine
 OIDC_CLIENT_ID=feminine-api
-OIDC_CLIENT_SECRET=feminine-api-secret
+OIDC_CLIENT_SECRET=change-me
+MAIL_HOST=localhost
+MAIL_PORT=1025
+MAIL_USERNAME=
+MAIL_PASSWORD=
+MAIL_START_TLS=OPTIONAL
+MAIL_NOTIFICATIONS_FROM=no-reply@feminine-portfolio.test
+MAIL_NOTIFICATIONS_COPY=
+RATE_LIMIT_CAPACITY=120
+RATE_LIMIT_REFILL=PT1M
+LOCAL_STORAGE_PATH=storage/images
+DEV_STORAGE_PATH=build/dev-images
+S3_BUCKET=
+S3_PREFIX=uploads
+S3_REGION=us-east-1
+S3_ENDPOINT=

--- a/api/README.md
+++ b/api/README.md
@@ -1,87 +1,50 @@
 # Feminine Photography API
 
-A Quarkus 3 based REST API that powers the feminine photography portfolio platform. The service exposes `/api/v1` endpoints for managing photographer profiles, albums, photos, inquiries and bookings. It integrates with PostgreSQL 16, Flyway migrations, Hibernate Panache, Bean Validation, OIDC/JWT security, rate limiting, OpenAPI/Swagger UI, health and metrics, plus an image storage abstraction that stores files locally in development and targets Amazon S3 in production.
+Quarkus 3 service that powers the portfolio web experience with REST resources for photographers, albums, photos, inquiries, and bookings.
 
-## Getting started
+## Prerequisites
+- **Java 21** (Temurin/OpenJDK). The Maven compiler is temporarily set to 17; install a Java 21 runtime so you can develop against the upcoming baseline while remaining compatible with the current build.【F:api/pom.xml†L14-L25】
+- **Maven 3.9+** for dependency management and the Quarkus CLI goals.【F:api/pom.xml†L11-L186】
+- **Docker** when running tests or local dependencies; the suite uses Testcontainers to launch PostgreSQL automatically.【F:api/src/test/java/com/feminine/api/config/PostgresResource.java†L1-L34】
 
-### Prerequisites
+## Environment setup
+1. Copy the template and provide local secrets:
+   ```bash
+   cp api/.env.example api/.env
+   ```
+   Populate JDBC credentials, OIDC client values, and mail configuration as needed. Never commit populated `.env` files—use GitHub Secrets or your platform secret manager for non-local environments.【F:api/.env.example†L1-L23】【F:api/.env†L1-L6】
+2. Ensure `application.properties` stays secret-free by referencing environment variables (`DB_*`, `OIDC_*`, `MAIL_*`, `S3_*`, etc.) when promoting to shared environments.【F:api/src/main/resources/application.properties†L1-L63】
 
-* Java 17+
-* Maven 3.9+
-* PostgreSQL 16 (for local development)
-* Docker (for running the Testcontainers powered test-suite)
+## Running locally
+1. Start PostgreSQL and Keycloak via the root docker-compose file or your preferred services.
+   ```bash
+   docker compose up -d postgres keycloak
+   ```
+2. Launch Quarkus in dev mode:
+   ```bash
+   cd api
+   mvn quarkus:dev
+   ```
+   Dev services auto-run Flyway migrations and expose Swagger UI at `http://localhost:8080/swagger-ui` and OpenAPI at `/q/openapi`. Seed data from `db/migration` populates reference photographers, albums, and bookings.【F:api/src/main/resources/db/migration/V1__create_tables.sql†L1-L200】
+3. Use the `/api/v1` endpoints for CRUD operations; authentication expects the Keycloak realm defined in `docker/keycloak/feminine-realm.json`.【F:api/src/main/java/com/feminine/api/resource/PhotographerResource.java†L1-L58】【F:docker/keycloak/feminine-realm.json†L1-L48】
 
-### First run
+## Database migrations
+- Flyway migrations live under `src/main/resources/db/migration` and run automatically at application start. Use `mvn quarkus:dev` or `mvn quarkus:run` to apply them locally, or execute `mvn -Dflyway.clean`/`mvn -Dflyway.migrate` for manual control if needed.【F:api/src/main/resources/application.properties†L1-L63】
+- When adding migrations, follow the `V#__description.sql` naming convention so Flyway orders them correctly.
 
-```bash
-cd api
-mvn quarkus:dev
-```
+## Testing
+- Execute the full suite with:
+  ```bash
+  mvn verify
+  ```
+  This command runs unit tests, Quarkus integration tests, and enforces the Jacoco 70% coverage threshold. Docker must be running for Testcontainers to provision PostgreSQL.【F:api/pom.xml†L145-L186】【F:api/src/test/java/com/feminine/api/config/PostgresResource.java†L1-L34】
+- Use `mvn test` for faster feedback when you do not need integration tests or coverage checks.
 
-This will start Quarkus in dev mode on <http://localhost:8080>. Swagger UI is served from [`/swagger-ui`](http://localhost:8080/swagger-ui) and the OpenAPI contract lives at [`/q/openapi`](http://localhost:8080/q/openapi).
+## Common issues
+- **Testcontainers cannot start PostgreSQL**: Verify Docker is installed and running, and that ports 5432/5433 are free. Retry `mvn verify` after pruning old containers.【F:api/src/test/java/com/feminine/api/config/PostgresResource.java†L1-L34】
+- **OIDC failures (401/403)**: Confirm the `OIDC_*` values in `api/.env` match the Keycloak realm imported from `docker/keycloak/feminine-realm.json`, and that the Keycloak server is reachable.【F:api/.env.example†L1-L23】【F:docker/keycloak/feminine-realm.json†L1-L48】
+- **Image upload errors**: The `PhotoService` depends on an `ImageStorageService` adapter that has not been implemented yet; expect failures on `/api/v1/photos` upload/update operations until the storage layer is delivered.【F:api/src/main/java/com/feminine/api/service/PhotoService.java†L1-L69】
 
-Flyway automatically runs the SQL migrations in `src/main/resources/db/migration`. The seed data inserts two photographers, sample albums, photos, inquiries and bookings.
-
-### Configuration profiles
-
-* **Dev** (`quarkus.profile=dev`) — Uses the local PostgreSQL connection configured through the `DEV_DB_*` environment variables (defaults are provided). Images are stored under `build/dev-images`.
-* **Test** (`quarkus.profile=test`) — Bootstrapped by the Testcontainers based `PostgresResource`. Stored images are written to `target/test-images`.
-* **Prod** (`quarkus.profile=prod`) — Reads all DB and S3 configuration from the `PROD_*` environment variables. Enables the S3 storage adapter.
-
-OIDC/JWT validation is pre-configured; provide `OIDC_AUTH_SERVER_URL`, `OIDC_CLIENT_ID`, `OIDC_CLIENT_SECRET` and a PEM encoded public key at `src/main/resources/keys/publicKey.pem` (or override `quarkus.smallrye-jwt.verify.key.location`).
-
-### Core endpoints
-
-| Resource | Endpoint | Description |
-| --- | --- | --- |
-| Photographers | `GET /api/v1/photographers` | List photographer profiles |
-|  | `POST /api/v1/photographers` | Create a profile |
-|  | `GET/PUT/DELETE /api/v1/photographers/{id}` | Retrieve, update or delete a profile |
-| Albums | `GET /api/v1/photographers/{photographerId}/albums` | List albums for a photographer |
-|  | `POST /api/v1/albums` | Create an album |
-|  | `GET/PUT/DELETE /api/v1/albums/{id}` | Retrieve, update or delete an album |
-| Photos | `GET /api/v1/albums/{albumId}/photos` | List photos |
-|  | `POST /api/v1/photos` *(multipart)* | Upload a new photo and metadata |
-|  | `PUT /api/v1/photos/{id}` | Update metadata |
-|  | `POST /api/v1/photos/{id}/image` *(multipart)* | Replace the stored image |
-|  | `DELETE /api/v1/photos/{id}` | Delete a photo |
-| Inquiries | `GET /api/v1/photographers/{photographerId}/inquiries` | List inquiries |
-|  | `POST /api/v1/inquiries` | Create inquiry |
-|  | `PUT /api/v1/inquiries/{id}` | Update inquiry |
-|  | `POST /api/v1/inquiries/{id}/status` | Update status |
-|  | `POST /api/v1/inquiries/{id}/messages/outbound` | Send an email response |
-|  | `POST /api/v1/inquiries/{id}/messages/inbound` | Record inbound email content |
-|  | `DELETE /api/v1/inquiries/{id}` | Delete inquiry |
-| Bookings | `GET /api/v1/photographers/{photographerId}/bookings` | List bookings |
-|  | `POST /api/v1/bookings` | Create booking |
-|  | `PUT /api/v1/bookings/{id}` | Update booking |
-|  | `POST /api/v1/bookings/{id}/status` | Update status and contract URL |
-|  | `POST /api/v1/bookings/{id}/messages/outbound` | Send an email update |
-|  | `POST /api/v1/bookings/{id}/messages/inbound` | Record inbound client email |
-|  | `DELETE /api/v1/bookings/{id}` | Delete booking |
-
-Rate limiting is enforced for every `/api/` call using Bucket4j. Default values (120 requests/minute) can be tuned with `RATE_LIMIT_CAPACITY` and `RATE_LIMIT_REFILL` environment variables.
-
-### Email notifications & ingestion
-
-The API relies on the Quarkus Mailer extension to deliver acknowledgements, notifications and ad-hoc replies for inquiries and bookings. Configure the SMTP gateway via `quarkus.mailer.*` properties and customise the sender/copy addresses with `mail.notifications.from` and `mail.notifications.copy`. For development and automated tests, email delivery is mocked by default.
-
-Inbound email webhooks can post to `POST /api/v1/inquiries/{id}/messages/inbound` and `POST /api/v1/bookings/{id}/messages/inbound` to archive replies from clients while simultaneously notifying the associated photographer.
-
-### Health, metrics and tracing
-
-* Liveness/readiness checks at `/q/health` and `/q/health/ready` (database readiness check included)
-* Prometheus metrics at `/q/metrics`
-* Audit logging is applied to all mutating service operations
-
-### Testing & coverage
-
-Run the full test-suite (requires Docker):
-
-```bash
-cd api
-mvn verify
-```
-
-`mvn verify` executes unit tests plus the Quarkus/RestAssured integration tests on a PostgreSQL 16 Testcontainer. JaCoCo is configured to enforce a minimum 70% line coverage across the module.
-
+## Secret management
+- Keep all runtime secrets in GitHub Secrets or your deployment platform’s vault. Reference them from CI/CD workflows and (future) infrastructure code instead of modifying repository files.
+- If you must share local defaults, update `api/.env.example` with sanitized placeholders rather than pushing populated `.env` files.【F:api/.env.example†L1-L23】

--- a/audit-report.md
+++ b/audit-report.md
@@ -1,0 +1,60 @@
+# Delivery Epic Audit Report
+
+## Executive summary
+- The front-end Vite/React application is feature-rich with localized marketing pages and admin tooling, but automated tests and runtime observability are not yet wired to the Quarkus back end the way the epic envisions.
+- The Quarkus service exposes a comprehensive domain model (photographers, albums, photos, inquiries, bookings) with Flyway migrations and email workflows, yet key integrations such as object storage and hardened configuration for higher environments remain incomplete.
+- Infrastructure automation currently stops at docker-compose for local orchestration; there is no codified cloud baseline or CI/CD workflow managing secrets, so the epic’s deployment and compliance goals are still unmet.
+
+## Front-end (web module)
+### Current state
+- Routes are implemented for all public marketing surfaces plus the admin dashboard, backed by a language provider that toggles between Bulgarian and English strings for core UI copy.【F:src/Routes.jsx†L1-L37】【F:src/hooks/useLanguage.jsx†L1-L99】
+- API service wrappers are in place for bookings, galleries, and stories, reusing a shared Axios client that reads the base URL from Vite environment variables to call the Quarkus API.【F:src/services/booking.js†L1-L42】【F:src/services/gallery.js†L1-L15】【F:src/services/apiClient.js†L1-L9】
+- The admin dashboard renders extensive UI scaffolding (stats, notifications, schedule widgets) but currently relies on hard-coded sample data rather than live API payloads.【F:src/pages/admin-dashboard/index.jsx†L1-L86】
+
+### Gaps and risks
+- The project scripts still rely on `bun test` even though Bun is neither installed nor documented, leaving the front-end test suite effectively unusable for contributors following Node/NPM workflows.【F:package.json†L43-L52】
+- There is no documented or implemented telemetry/monitoring hook from the front end to surface API health, making it difficult to satisfy the epic’s operational readiness expectations.
+- Localization only covers copy strings; date/time formatting and API payloads remain single-locale, and there is no fallback content strategy for untranslated assets, risking inconsistent UX.
+
+### Implementation plan
+1. Replace the `bun test` script with a supported Jest or Vitest runner and add smoke tests that exercise the Axios client against a mocked API to reestablish the red/green feedback loop envisioned in the epic.
+2. Wire the admin dashboard widgets to the booking, inquiry, and gallery endpoints (via Redux Toolkit or React Query) and add loading/error states so the UI reflects real operational data.
+3. Expand the localization provider to wrap API-bound content (e.g., booking form labels, currency formatting) and document language toggle constraints for content editors.
+
+## Back-end (api module)
+### Current state
+- Maven builds a Quarkus 3.8 application targeting Java 17 with RESTEasy Reactive, Hibernate Panache, Flyway, OIDC, metrics, and Mailer integrations; S3 support is declared for future image storage work.【F:api/pom.xml†L11-L109】
+- Domain aggregates, DTOs, and REST resources cover photographers, albums, photos, inquiries, and bookings, matching the epic’s CRUD and workflow scope.【F:api/src/main/java/com/feminine/api/resource/PhotographerResource.java†L1-L58】【F:api/src/main/java/com/feminine/api/service/EmailService.java†L1-L120】
+- Environment-aware configuration values default via Quarkus properties, and Flyway SQL migrations seed initial data for local environments.【F:api/src/main/resources/application.properties†L1-L63】【F:api/src/main/resources/db/migration/V1__create_tables.sql†L1-L200】
+- The test suite bootstraps PostgreSQL through Testcontainers and enables Flyway cleaning to keep database fixtures deterministic.【F:api/src/test/java/com/feminine/api/config/PostgresResource.java†L1-L34】【F:api/src/test/resources/application.properties†L1-L6】
+
+### Gaps and risks
+- The service layer references an `ImageStorageService` in an `infrastructure` package that is absent from the repository, so photo uploads will fail at runtime until the storage adapter is implemented.【F:api/src/main/java/com/feminine/api/service/PhotoService.java†L1-L69】
+- Security is configured for OIDC, yet the committed `.env` file and Keycloak realm expose default secrets that should be rotated and stored in a secrets manager before staging or production releases.【F:api/.env†L1-L6】【F:docker/keycloak/feminine-realm.json†L1-L48】
+- The Maven compiler release remains pinned to Java 17 while the epic targets Java 21, and there is no CI gate enforcing the Jacoco coverage rule declared in the POM.【F:api/pom.xml†L12-L25】【F:api/pom.xml†L145-L186】
+
+### Implementation plan
+1. Deliver the missing `ImageStorageService` abstraction with local filesystem and S3 implementations, validating multipart upload flows via integration tests.
+2. Upgrade the Maven toolchain to Java 21, align container images and Compose services with that baseline, and add compatibility notes for contributors.
+3. Harden secrets by replacing the committed `.env` defaults with template files, provisioning GitHub environment secrets for CI/CD, and updating Keycloak client credentials across environments.
+
+## Infrastructure
+### Current state
+- Docker Compose provisions PostgreSQL 16, Keycloak 25, the Quarkus API, and the Vite web app for local development, wiring environment variables for OIDC and service discovery.【F:docker-compose.yml†L1-L73】
+- A Keycloak realm export defines web and API clients plus a seeded operator account to support the OIDC flow exercised by the application.【F:docker/keycloak/feminine-realm.json†L1-L48】
+- Environment templates exist for the web app, and a new API template has been added to guide local secret population without committing production values.【F:.env.example†L1-L10】【F:api/.env.example†L1-L23】
+
+### Gaps and risks
+- There is no dedicated `infra` module or IaC definition for cloud databases, storage, identity, or networking, leaving the epic’s deployment targets undefined beyond local Compose files.【d94442†L1-L4】
+- The repository lacks GitHub Actions or any CI/CD automation, so tests, security scans, and deployments are entirely manual at this stage.【d93ced†L1-L9】
+- Secrets required for Compose and Keycloak are checked into source control, conflicting with the epic’s compliance needs and raising rotation risks if reused outside local development.【F:api/.env†L1-L6】【F:docker/keycloak/feminine-realm.json†L1-L48】
+
+### Implementation plan
+1. Stand up an `infra/` module (Terraform or Pulumi) that codifies PostgreSQL, object storage, Keycloak, and networking for non-local environments, seeded from the Compose topology.
+2. Author GitHub Actions workflows that build/test the `web` and `api` modules, publish container images, and promote infrastructure changes, sourcing credentials from GitHub Secrets.
+3. Externalize local secrets by relying on the new `.env` templates, removing committed secrets, and documenting secret rotation procedures for both local Compose and GitHub-hosted environments.
+
+## Implementation roadmap
+1. **Stabilize developer workflows** — Fix front-end testing, provide storage stubs, and migrate secrets to templates so contributors can run the stack locally with confidence.
+2. **Align with production standards** — Upgrade to Java 21, implement storage and email providers, and introduce monitoring/telemetry hooks across web and API tiers.
+3. **Automate delivery** — Add CI/CD pipelines, codify infrastructure, and connect pipelines to GitHub Secrets for deployments that satisfy the epic’s governance requirements.


### PR DESCRIPTION
## Summary
- add an audit report covering the state of the web, api, and infrastructure workstreams
- rewrite the root README with prerequisites, environment setup, quick start flows, and secret-management guidance
- refresh the API README and .env template with backend-specific setup, testing, and troubleshooting notes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cbf24cd3d48321bfe74f6a7533ac57